### PR TITLE
Fix printf flag inversion issue

### DIFF
--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -1,7 +1,8 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8)
 project(zdw)
 
 add_definitions(-D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS)
+add_compile_options("-Wall")
 
 add_library(zdw
 	UnconvertFromZDW.cpp
@@ -35,7 +36,7 @@ find_package(Threads REQUIRED)
 
 include_directories( zdw ${CMAKE_CURRENT_SOURCE_DIR} ${ZLIB_INCLUDE_DIRS} )
 
-# for cmake 2.6 compatibility, can't automatically handle include files
+# TODO: Investigate setting this flag on CMAKE 2.8+
 # target_include_directories( zdw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${ZLIB_INCLUDE_DIRS} )
 
 target_link_libraries(zdw ${ZLIB_LIBRARIES})

--- a/cplusplus/includes.h
+++ b/cplusplus/includes.h
@@ -24,8 +24,7 @@
 #ifdef PRIu64
 #define PF_LLU PRIu64
 #else
-#include <limits.h>
-#if ULONG_MAX==1844674073709551615
+#if (_LP64 || __LP64__) // i.e., sizeof(uint64_t) == sizeof(unsigned long)
 #define PF_LLU "lu"
 #else
 #define PF_LLU "llu"

--- a/cplusplus/includes.h
+++ b/cplusplus/includes.h
@@ -26,9 +26,9 @@
 #else
 #include <limits.h>
 #if ULONG_MAX==1844674073709551615
-#define PF_LLU "ul"
+#define PF_LLU "lu"
 #else
-#define PF_LLU "ull"
+#define PF_LLU "llu"
 #endif
 #endif
 


### PR DESCRIPTION
* Fix lu/llu inversion in printf specifier in C++ code.  
* Use LP64 data model preprocessor define to detect appropriate lu/llu flag.
* Upgrades minimum cmake dependency to 2.8 and enables the "-Wall" flag.

## Description

<!--- Describe your changes in detail -->

## Related Issue

Closes #1 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

Manual testing performed.  

* Binary built using G++ 7.1 under CentOS 6.2, with the warning level increased via `-Wall`, with both 32bit and 64bit compilation.  
  * Verified warnings existed prior to change, and that formatting warnings no longer printed after change. 
  * Verified that both unconverted still successfully unconvert the movie_tickets.zdw.xz file with the same content
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

