### PR TITLE
Revert to support cmake-2.6 and some whitespace cleanup

### DIFF
--- a/cplusplus/.gitignore
+++ b/cplusplus/.gitignore
@@ -1,0 +1,12 @@
+
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+
+Makefile
+
+libzdw.a
+
+convertDWfile
+unconvertDWfile
+

--- a/cplusplus/BufferedInput.h
+++ b/cplusplus/BufferedInput.h
@@ -25,7 +25,7 @@ class BufferedInput
 public:
 	// either open a pipe with a command, and read input from the pipe,
 	// or open a gz file and read via zlib API
-	BufferedInput(const char* command, const size_t capacity=16*1024, bool is_gz_file=false)
+	BufferedInput(const char* command, const size_t capacity = 16 * 1024, bool is_gz_file = false)
 		: fp(NULL)
 		, gzFp(NULL)
 		, buffer(NULL)
@@ -61,7 +61,7 @@ public:
 	}
 
 	void close() {
-		if(is_gz_file) {
+		if (is_gz_file) {
 			if (gzFp) {
 				gzclose(gzFp);
 				gzFp = NULL;
@@ -94,13 +94,13 @@ public:
 	}
 
 	//Returns: whether file handle appears to be open
-	bool is_open() const {return (this->fp != NULL) || this->bFromStdin || this->gzFp; }
+	bool is_open() const { return (this->fp != NULL) || this->bFromStdin || this->gzFp; }
 
 	//Input source.
 	//Either must be set explicitly in order to avoid inadvertent reads from an unexpected source.
-	void readFromStdin(const bool bVal=true) {this->bFromStdin = bVal;}
+	void readFromStdin(const bool bVal = true) { this->bFromStdin = bVal; }
 
-	void reset() {index = length = 0;}
+	void reset() { index = length = 0; }
 
 	bool can_read_more_data() const {
 		if (eof())
@@ -119,7 +119,7 @@ public:
 		this->index = this->length = 0;
 		do {
 			//Iterate reads when we don't receive the entire buffer immediately.
-			if(is_gz_file)
+			if (is_gz_file)
 			{
 				this->length += gzread(this->gzFp, this->buffer + this->length,
 					this->capacity - this->length);
@@ -140,8 +140,8 @@ public:
 		if (this->bFromStdin)
 			return fgets(buf, size, stdin);
 
-		const size_t size_minus_1 = size-1;
-		size_t out_pos=0;
+		const size_t size_minus_1 = size - 1;
+		size_t out_pos = 0;
 		while (can_read_more_data()) {
 			while (this->index < this->length) {
 				if (out_pos == size_minus_1) {
@@ -200,7 +200,7 @@ public:
 			{
 				//Buffer is not large enough to store the rest of the requested data.
 				//Just pass the rest of the data through without buffering.
-				if(is_gz_file)
+				if (is_gz_file)
 				{
 					bytesRead += gzread(this->gzFp, data, size);
 					this->bEOF = gzeof(this->gzFp) != 0;
@@ -239,10 +239,10 @@ public:
 
 		if (this->bFromStdin) {
 			//Skips ahead the requested number of bytes in stdin.
-			size_t advanced=0;
+			size_t advanced = 0;
 
-			const size_t blocks=size/BLOCK_SIZE;
-			for (i=0; i<blocks; ++i) {
+			const size_t blocks = size/BLOCK_SIZE;
+			for (i = 0; i < blocks; ++i) {
 				bytes_read = fread(tempBlock, 1, BLOCK_SIZE, stdin);
 				advanced += bytes_read;
 				size -= bytes_read;
@@ -277,9 +277,9 @@ public:
 		size_t advanced = bytesInBuffer;
 
 		//2. Skip ahead the remaining number of bytes.
-		const size_t blocks=size/BLOCK_SIZE;
-		for (i=0; i<blocks; ++i) {
-			if(is_gz_file)
+		const size_t blocks = size / BLOCK_SIZE;
+		for (i = 0; i < blocks; ++i) {
+			if (is_gz_file)
 			{
 				bytes_read = gzread(this->gzFp, tempBlock, BLOCK_SIZE);
 			} else {
@@ -289,7 +289,7 @@ public:
 			size -= bytes_read;
 		}
 		assert(size < BLOCK_SIZE);
-		if(is_gz_file)
+		if (is_gz_file)
 		{
 			advanced += gzread(this->gzFp, tempBlock, size);
 			this->bEOF = gzeof(this->gzFp) != 0;
@@ -306,7 +306,7 @@ public:
 		assert(!gzFp);
 		assert(!fp);
 
-		if(is_gz_file)
+		if (is_gz_file)
 			gzFp = gzopen(command.c_str(), "rb");
 		else
 			fp = popen(command.c_str(), "r");

--- a/cplusplus/BufferedInput.h
+++ b/cplusplus/BufferedInput.h
@@ -211,7 +211,7 @@ public:
 
 				//Buffer is now empty -- refill next call
 				this->index = this->length = 0;
-				
+
 				return bytesRead;
 			}
 
@@ -258,7 +258,7 @@ public:
 		if (is_gz_file) {
 			if (!this->gzFp)
 				return 0;
-		} else if (!this->fp){			
+		} else if (!this->fp){
 			return 0;
 		}
 
@@ -284,7 +284,7 @@ public:
 				bytes_read = gzread(this->gzFp, tempBlock, BLOCK_SIZE);
 			} else {
 				bytes_read = fread(tempBlock, 1, BLOCK_SIZE, this->fp);
-			}		
+			}
 			advanced += bytes_read;
 			size -= bytes_read;
 		}
@@ -297,7 +297,7 @@ public:
 			advanced += fread(tempBlock, 1, size, this->fp);
 			this->bEOF = feof(this->fp) != 0;
 		}
-		
+
 		return advanced;
 	}
 

--- a/cplusplus/BufferedInput.h
+++ b/cplusplus/BufferedInput.h
@@ -191,7 +191,7 @@ public:
 
 				//Prepare to fill the output buffer with more data.
 				size -= bytesInBuffer;
-				data = (char*)data + bytesInBuffer;
+				data = static_cast<char*>(data) + bytesInBuffer;
 				bytesRead = bytesInBuffer;
 			}
 

--- a/cplusplus/BufferedOutput.cpp
+++ b/cplusplus/BufferedOutput.cpp
@@ -14,11 +14,13 @@
 
 int compareByIndex(const void * first, const void * second)
 {
-	return (*(OutputOrderIndexer *)first).index - (*(OutputOrderIndexer *)second).index;
+	return (reinterpret_cast<const OutputOrderIndexer *>(first))->index
+			- (reinterpret_cast<const OutputOrderIndexer *>(second))->index;
 }
 
 int compareByOutputIndex(const void * first, const void * second)
 {
-	return (*(OutputOrderIndexer *)first).outputIndex - (*(OutputOrderIndexer *)second).outputIndex;
+	return (reinterpret_cast<const OutputOrderIndexer *>(first))->outputIndex
+			- (reinterpret_cast<const OutputOrderIndexer *>(second))->outputIndex;
 }
 

--- a/cplusplus/BufferedOutput.cpp
+++ b/cplusplus/BufferedOutput.cpp
@@ -12,13 +12,13 @@
 
 #include "BufferedOutput.h"
 
-int compareByIndex(const void * first, const void * second)
+int compareByIndex(const void* first, const void* second)
 {
 	return (reinterpret_cast<const OutputOrderIndexer *>(first))->index
 			- (reinterpret_cast<const OutputOrderIndexer *>(second))->index;
 }
 
-int compareByOutputIndex(const void * first, const void * second)
+int compareByOutputIndex(const void* first, const void* second)
 {
 	return (reinterpret_cast<const OutputOrderIndexer *>(first))->outputIndex
 			- (reinterpret_cast<const OutputOrderIndexer *>(second))->outputIndex;

--- a/cplusplus/BufferedOutput.h
+++ b/cplusplus/BufferedOutput.h
@@ -135,7 +135,7 @@ public:
 				str.append(1, '\t'); //force column separators to be tabs for now
 			colBuf->print(str);
 		}
-		str.append((const char*)data, size); //append the endline chars
+		str.append(static_cast<const char*>(data), size); //append the endline chars
 		return (fwrite(str.c_str(), str.size(), 1, this->fp) == 1);
 	}
 

--- a/cplusplus/BufferedOutput.h
+++ b/cplusplus/BufferedOutput.h
@@ -263,7 +263,7 @@ extern int compareByOutputIndex(const void * first, const void * second);
 class BufferedOutputInMem
 {
 public:
-	
+
 	BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer=true)
 		: ppBuffer(NULL)
 		, pBuffer(NULL)
@@ -333,7 +333,7 @@ public:
 
 		this->numColumns = validNumColumns;
 		this->pColumnsBuffer = new const char*[validNumColumns];
-				
+
 		this->bNeedReorder = true;
 		return true;
 	}
@@ -341,7 +341,7 @@ public:
 	bool write(const void* data, const size_t size) {
 		assert(ppBuffer || bUseInternalBuffer);
 		assert(pBuffer);
-		
+
 		//Add data to current column value.
 		memcpy(this->pBuffer + this->index, data, size);
 		this->index += size;

--- a/cplusplus/BufferedOutput.h
+++ b/cplusplus/BufferedOutput.h
@@ -30,7 +30,7 @@ private:
 	//Used for reordering column outputs.
 	class ByteBuffer {
 	public:
-		ByteBuffer(int unsigned startSize=16)
+		ByteBuffer(int unsigned startSize = 16)
 		: pBuffer(new char[startSize])
 		, size(0)
 		, capacity(startSize)
@@ -49,7 +49,7 @@ private:
 			swap(this->capacity, rhs.capacity);
 		}
 		ByteBuffer& operator=(const ByteBuffer& rhs) { ByteBuffer(rhs).swap(*this); return *this; }
-		~ByteBuffer() {delete[] this->pBuffer;}
+		~ByteBuffer() { delete[] this->pBuffer; }
 
 		//Write data to the start of the buffer.
 		inline void write(const void* data, const size_t dataSize) {
@@ -73,7 +73,7 @@ private:
 		inline void print(std::string& str) const { str.append(this->pBuffer, this->size); }
 
 	private:
-		char *pBuffer;
+		char* pBuffer;
 		int size;
 		int unsigned capacity;
 	};
@@ -150,7 +150,7 @@ public:
 
 		//Populate column order and buffer to hold each column output.
 		int max_val = -1; //enforce no gaps in the sequence
-		for (int i=0; i<numColumns; ++i) {
+		for (int i = 0; i < numColumns; ++i) {
 			const int val = pOutputOrder[i];
 			if (val != -1) { //skip -1 values (use this to indicate a column is being omitted)
 				assert(val >= 0); //negative values are not supported
@@ -166,12 +166,12 @@ public:
 		//i.e. the number of elements added should equal the largest value encountered
 		//     (actually, one greater than the highest zero-based index)
 		//CAVEAT: this doesn't catch pathological cases (e.g. "2, 2, 2" where the size is one greater than the max_val)
-		return (max_val+1) == int(this->outputIndex.size());
+		return (max_val + 1) == int(this->outputIndex.size());
 	}
-	void setOutputColumnPtrs(const char**) {} //not needed in this class template version
+	void setOutputColumnPtrs(const char**) { } //not needed in this class template version
 
 private:
-	FILE *const fp;
+	FILE* const fp;
 
 	//for (re)ordering column outputs within a line of text
 	std::vector<int> outputIndex; //input --> output index remapping
@@ -187,7 +187,7 @@ private:
 	BufferedOutput &operator=(BufferedOutput const &);
 
 public:
-	BufferedOutput(FILE* fp, const size_t capacity=16*1024)
+	BufferedOutput(FILE* fp, const size_t capacity = 16 * 1024)
 		: fp(fp)
 		, capacity(capacity)
 		, buffer(fp ? new char[capacity] : NULL)
@@ -231,7 +231,7 @@ public:
 		}
 		return bRet;
 	}
-	void writeEmpty() {}
+	void writeEmpty() { }
 
 	//Output a separator between columns.
 	bool writeSeparator(const void* data, const size_t size) { return write(data, size); }
@@ -239,13 +239,13 @@ public:
 	//Completes the current row/line of text.
 	bool writeEndline(const void* data, const size_t size) { return write(data, size); }
 
-	bool setOutputColumnOrder(const int*, const int) {return true;} //not needed here -- use BufferedOrderedOutput if this functionality is desired
-	void setOutputColumnPtrs(const char**) {} //not needed in this class template version
+	bool setOutputColumnOrder(const int*, const int) { return true; } //not needed here -- use BufferedOrderedOutput if this functionality is desired
+	void setOutputColumnPtrs(const char**) { } //not needed in this class template version
 
 private:
-	FILE *const fp;
+	FILE* const fp;
 	const size_t capacity;
-	char *const buffer;
+	char* const buffer;
 
 	size_t index;
 };
@@ -256,15 +256,15 @@ struct OutputOrderIndexer
 	int outputIndex;
 };
 
-extern int compareByIndex(const void * first, const void * second);
-extern int compareByOutputIndex(const void * first, const void * second);
+extern int compareByIndex(const void* first, const void* second);
+extern int compareByOutputIndex(const void* first, const void* second);
 
 //Class to output each row's column values to user-specified char**s.
 class BufferedOutputInMem
 {
 public:
 
-	BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer=true)
+	BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer = true)
 		: ppBuffer(NULL)
 		, pBuffer(NULL)
 		, pBufferSize(NULL)
@@ -277,7 +277,7 @@ public:
 		, bUseInternalBuffer(bUseInternalBuffer)
 		, bNeedReorder(false)
 	{
-		if(bUseInternalBuffer)
+		if (bUseInternalBuffer)
 		{
 			this->pBuffer = new char[neededBufferSize];
 		}
@@ -287,12 +287,12 @@ public:
 	{
 		delete[] this->pOutputOrder;
 		delete[] this->pColumnsBuffer;
-		if(bUseInternalBuffer)
+		if (bUseInternalBuffer)
 			delete [] this->pBuffer;
 	}
 
 	// invoke setOutputBuffer before parsing
-	void setOutputBuffer(char ** buffer, size_t *size)
+	void setOutputBuffer(char** buffer, size_t *size)
 	{
 		assert(buffer);
 		assert(*buffer);
@@ -314,16 +314,16 @@ public:
 
 	bool setOutputColumnOrder(const int* pOutputOrder, const int numColumns) {
 
-		if(!pOutputOrder || numColumns == 0)
+		if (!pOutputOrder || numColumns == 0)
 		{
 			return true;
 		}
 
 		this->pOutputOrder = new int[numColumns];
 		int validNumColumns = 0;
-		for(int i=0; i<numColumns; i++)
+		for (int i = 0; i < numColumns; i++)
 		{
-			if(pOutputOrder[i] == -1)
+			if (pOutputOrder[i] == -1)
 			{
 				continue;
 			}
@@ -348,7 +348,7 @@ public:
 		assert(bUseInternalBuffer || this->index < *pBufferSize);
 		return true;
 	}
-	void writeEmpty() {}
+	void writeEmpty() { }
 
 	bool writeSeparator(const void* /*data*/, const size_t /*size*/) {
 		assert(ppBuffer || bUseInternalBuffer);
@@ -370,7 +370,7 @@ public:
 		this->pBuffer[this->index] = 0; //null-delimiter
 		this->currentRowLength = this->index;
 
-		if(this->bNeedReorder)
+		if (this->bNeedReorder)
 		{
 			reorderOutputColumn();
 		}
@@ -395,12 +395,12 @@ public:
 private:
 	void reorderOutputColumn()
 	{
-		if(!pOutputOrder || numColumns == 0 || !pColumns)
+		if (!pOutputOrder || numColumns == 0 || !pColumns)
 		{
 			return;
 		}
 
-		for(int i=0; i<numColumns; i++)
+		for (int i = 0; i < numColumns; i++)
 		{
 			pColumnsBuffer[pOutputOrder[i]] = pColumns[i];
 		}
@@ -411,7 +411,7 @@ private:
 	{
 		assert(pBufferSize);
 		assert(ppBuffer);
-		if(requiredSize > *pBufferSize){
+		if (requiredSize > *pBufferSize){
 			delete [] pBuffer;
 			pBuffer = new char [requiredSize];
 			*ppBuffer = pBuffer;

--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
 project(zdw)
 
-add_definitions(-D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS -Wall)
+add_definitions(-D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS -Wall -Wold-style-cast)
 
 add_library(zdw
 	UnconvertFromZDW.cpp

--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -1,8 +1,7 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.6)
 project(zdw)
 
-add_definitions(-D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS)
-add_compile_options("-Wall")
+add_definitions(-D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS -Wall)
 
 add_library(zdw
 	UnconvertFromZDW.cpp
@@ -36,7 +35,7 @@ find_package(Threads REQUIRED)
 
 include_directories( zdw ${CMAKE_CURRENT_SOURCE_DIR} ${ZLIB_INCLUDE_DIRS} )
 
-# TODO: Investigate setting this flag on CMAKE 2.8+
+# for cmake 2.6 compatibility, can't automatically handle include files
 # target_include_directories( zdw PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${ZLIB_INCLUDE_DIRS} )
 
 target_link_libraries(zdw ${ZLIB_LIBRARIES})

--- a/cplusplus/ConvertToZDW.cpp
+++ b/cplusplus/ConvertToZDW.cpp
@@ -640,7 +640,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 	temp_outfile_name += temp_suffix;
 	temp_outfile_name += ".zdw";
 	temp_outfile_name += getExtensionForCompressor();
-	
+
 	string cmd = getCompressionCommand();
 	if (zArgs) {
 		cmd += " ";

--- a/cplusplus/ConvertToZDW.cpp
+++ b/cplusplus/ConvertToZDW.cpp
@@ -407,7 +407,7 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 //Returns: number of columns with non-default values.
 size_t ConvertToZDW::writeLookupColumnStats(FILE* out, const size_t numColumns)
 {
-	const char offsetSize = (char)this->uniques.getBytesInOffset();
+	const char offsetSize = static_cast<char>(this->uniques.getBytesInOffset());
 
 	ULONGLONG *usedColumnMin = new ULONGLONG[numColumns];
 
@@ -754,7 +754,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 			//Open a temp file in the output dir in order to store
 			//the data being streamed in for the second read pass.
 			assert(!this->tmp_fp);
-			tmp_filename = (char*)malloc(strlen(zdwFile)+20);
+			tmp_filename = static_cast<char*>(malloc(strlen(zdwFile)+20));
 			sprintf(tmp_filename, "%s.tmp.%d.gz", outfile_basepath.c_str(), file_pieces);
 			string cmd = "gzip > "; //compress the data to reduce disk writes
 			cmd += tmp_filename;
@@ -867,7 +867,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 	if(bValidate)
 	{
 		//Ensure the ZDW file's output is identical to the input data.
-		assert(tmp_filenames.size() == (size_t)file_pieces); //if we're storing temp files, we need to validate against them all
+		assert(tmp_filenames.size() == static_cast<size_t>(file_pieces)); //if we're storing temp files, we need to validate against them all
 		const ERR_CODE eValid = validate(temp_outfile_name.c_str(), tmp_filenames, exeName, outputDir);
 
 		if(eValid == OK)

--- a/cplusplus/ConvertToZDW.cpp
+++ b/cplusplus/ConvertToZDW.cpp
@@ -81,9 +81,9 @@ int unsigned ConvertToZDW::ReadDescFile(FILE* f)
 	this->columnCharSize.clear();
 	m_ColumnType.reserve(MAX_EXPECTED_COLUMNS);
 	this->columnCharSize.reserve(MAX_EXPECTED_COLUMNS);
-	while(fgets(row, MAX_DESC_LINE_LENGTH, f))
+	while (fgets(row, MAX_DESC_LINE_LENGTH, f))
 	{
-		if(!strncasecmp(row, "Field", 5))
+		if (!strncasecmp(row, "Field", 5))
 			continue;
 
 		tab = strchr(row, '\t');
@@ -95,44 +95,44 @@ int unsigned ConvertToZDW::ReadDescFile(FILE* f)
 		this->columnCharSize.push_back(0); //default: don't care
 
 		++tab;
-		if(!strncmp(tab, "varchar", 7)) {
-			const int char_size = atoi(tab+8);
+		if (!strncmp(tab, "varchar", 7)) {
+			const int char_size = atoi(tab + 8);
 			m_ColumnType.push_back(VARCHAR);
 			this->columnCharSize.back() = char_size;
 		}
-		else if(!strncmp(tab, "char", 4))
+		else if (!strncmp(tab, "char", 4))
 		{
-			const int char_size = atoi(tab+5);
-			if(char_size == 1)
+			const int char_size = atoi(tab + 5);
+			if (char_size == 1)
 				m_ColumnType.push_back(CHAR);
-			else if(char_size == 2)
+			else if (char_size == 2)
 				m_ColumnType.push_back(CHAR_2);
 			else
 				m_ColumnType.push_back(VARCHAR); //don't care about representing the size of this char(x) field precisely
 			this->columnCharSize.back() = char_size;
 		}
-		else if(!strncmp(tab, "text", 4))
+		else if (!strncmp(tab, "text", 4))
 			m_ColumnType.push_back(TEXT);
-		else if(!strncmp(tab, "tinytext", 8))
+		else if (!strncmp(tab, "tinytext", 8))
 			m_ColumnType.push_back(TINYTEXT);
-		else if(!strncmp(tab, "mediumtext", 10))
+		else if (!strncmp(tab, "mediumtext", 10))
 			m_ColumnType.push_back(MEDIUMTEXT);
-		else if(!strncmp(tab, "longtext", 8))
+		else if (!strncmp(tab, "longtext", 8))
 			m_ColumnType.push_back(LONGTEXT);
-		else if(!strncmp(tab, "datetime", 8))
+		else if (!strncmp(tab, "datetime", 8))
 			m_ColumnType.push_back(DATETIME);
-		else if(!strncmp(tab, "decimal", 7) || !strncmp(tab+1, "decimal", 7))
+		else if (!strncmp(tab, "decimal", 7) || !strncmp(tab + 1, "decimal", 7))
 			m_ColumnType.push_back(DECIMAL);
 		else {
 			//Numeric values.
 			//Look for "unsigned" (ver6+).
 			const bool bSigned = (strstr(tab, "unsigned") == NULL);
 
-			if(!strncmp(tab, "tinyint", 7))
+			if (!strncmp(tab, "tinyint", 7))
 				m_ColumnType.push_back(bSigned ? TINY_SIGNED : TINY);
-			else if(!strncmp(tab, "smallint", 8))
+			else if (!strncmp(tab, "smallint", 8))
 				m_ColumnType.push_back(bSigned ? SHORT_SIGNED : SHORT);
-			else if(!strncmp(tab, "bigint", 6))
+			else if (!strncmp(tab, "bigint", 6))
 				m_ColumnType.push_back(bSigned ? LONGLONG_SIGNED : LONGLONG);
 			else
 				m_ColumnType.push_back(bSigned ? LONG_SIGNED : LONG);
@@ -159,10 +159,10 @@ ConvertToZDW::ERR_CODE ConvertToZDW::validate(
 	//Call unconvertDWfile at the same path location where this app was invoked.
 	string zdw_path = exeName;
 	//Strip the binary name off (everything after the final /).
-	const char *pos = exeName + strlen(exeName);  //start from end...
+	const char* pos = exeName + strlen(exeName);  //start from end...
 	while (pos > exeName && pos[-1] != '/') //...and look backwards
 		--pos;
-	zdw_path.resize(pos-exeName);
+	zdw_path.resize(pos - exeName);
 	//Stream ZDW output to validation process.
 	string zdw_cmd = zdw_path + "unconvertDWfile -q - ";
 
@@ -179,7 +179,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::validate(
 	if (this->bStreamingInput) {
 		//Stream from the series of .gz temp files.
 		string zcat_str = "zcat ";
-		for (size_t i=0; i<src_filenames.size(); ++i) {
+		for (size_t i = 0; i < src_filenames.size(); ++i) {
 			zcat_str += src_filenames[i];
 			zcat_str += " ";
 		}
@@ -207,18 +207,18 @@ ConvertToZDW::ERR_CODE ConvertToZDW::validate(
 inline void get_next_column(char*& col)
 {
 	col = strchr(col, '\t'); // embedded tabs are escaped by an odd number of backslashes.
-	if(col && col[-1] == '\\')
+	if (col && col[-1] == '\\')
 	{
 		char* slash = col - 2;
-		while(*slash == '\\')
+		while (*slash == '\\')
 			--slash;
-		while(col && ((col - slash) % 2) == 0)
+		while (col && ((col - slash) % 2) == 0)
 		{
-			col = strchr(col+1, '\t');
-			if(col)
+			col = strchr(col + 1, '\t');
+			if (col)
 			{
 				slash = col - 1;
-				while(*slash == '\\')
+				while (*slash == '\\')
 					--slash;
 			}
 		}
@@ -227,10 +227,10 @@ inline void get_next_column(char*& col)
 
 inline bool dump_trimmed_row_to_temp_file(FILE* fp, const vector<char*>& rowColumns)
 {
-	const int size_minus_one = rowColumns.size()-1;
+	const int size_minus_one = rowColumns.size() - 1;
 	char *field;
 	size_t len;
-	for (int i=0; i<size_minus_one; ++i) {
+	for (int i = 0; i < size_minus_one; ++i) {
 		field = rowColumns[i];
 		len = strlen(field);
 		if (len > 0 && fwrite(field, 1, len, fp) != len)
@@ -254,7 +254,7 @@ size_t ConvertToZDW::GetDataRow(
 {
 	rowColumns.clear();
 
-	if(Common::GetNextRow(f, row, m_LongestLine))
+	if (Common::GetNextRow(f, row, m_LongestLine))
 	{
 		//If we're streaming data in, store this data to a temp file
 		if (this->tmp_fp &&
@@ -269,11 +269,11 @@ size_t ConvertToZDW::GetDataRow(
 		}
 
 		char *col = row, *temp;
-		while(col)
+		while (col)
 		{
 			rowColumns.push_back(col);
 			get_next_column(col);
-			if(col) // replace the tab with an end of string null
+			if (col) // replace the tab with an end of string null
 			{
 				*col = 0;
 				++col;
@@ -317,16 +317,16 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 	bool hadEnoughMemory = true;
 	size_t n;
 	const size_t numColumns = m_ColumnType.size();
-	while(hadEnoughMemory && (n = GetDataRow(in, m_row, this->rowColumns)))
+	while (hadEnoughMemory && (n = GetDataRow(in, m_row, this->rowColumns)))
 	{
 		if (n != numColumns)
 			return IS_WRONG_NUM_OF_COLUMNS_ON_A_ROW;
-		for(size_t c = 0; hadEnoughMemory && c < n; ++c)
+		for (size_t c = 0; hadEnoughMemory && c < n; ++c)
 		{
-			if(!this->rowColumns[c][0])
+			if (!this->rowColumns[c][0])
 				continue; //skip empty values
 
-			switch(m_ColumnType[c])
+			switch (m_ColumnType[c])
 			{
 				case DECIMAL:
 				case VARCHAR:
@@ -345,13 +345,13 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 					val = this->rowColumns[c][0];
 					if (this->rowColumns[c][0] == '\\') //include escaped chars verbatim
 						val += (this->rowColumns[c][1] * 256);
-					if(val > 0)
+					if (val > 0)
 					{
-						if(minmaxset[c])
+						if (minmaxset[c])
 						{
-							if(val > columnMax[c])
+							if (val > columnMax[c])
 								columnMax[c] = val;
-							else if(val < columnMin[c])
+							else if (val < columnMin[c])
 								columnMin[c] = val;
 						}
 						else
@@ -371,13 +371,13 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 					//when gathering the range (though it is technically inaccurate).
 					ULONGLONG& val = columnVal[c];
 					val = strtoull(this->rowColumns[c], NULL, 10);
-					if(val > 0)
+					if (val > 0)
 					{
-						if(minmaxset[c])
+						if (minmaxset[c])
 						{
-							if(val > columnMax[c])
+							if (val > columnMax[c])
 								columnMax[c] = val;
-							else if(val < columnMin[c])
+							else if (val < columnMin[c])
 								columnMin[c] = val;
 						}
 						else
@@ -391,10 +391,10 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 				default: assert(!"Unrecognized column type"); break;
 			}
 		}
-		if(hadEnoughMemory)
+		if (hadEnoughMemory)
 		{
 			++this->numRows;
-			if(!(this->numRows % 10000) && !this->bQuiet)
+			if (!(this->numRows % 10000) && !this->bQuiet)
 			{
 				printf("\r%u rows", this->numRows);
 				fflush(stdout);
@@ -414,9 +414,9 @@ size_t ConvertToZDW::writeLookupColumnStats(FILE* out, const size_t numColumns)
 	//Determine size of columns in this block.  If column is empty, mark it unused.
 	size_t numColumnsUsed = 0;
 	ULONGLONG val;
-	for(size_t c = 0; c < numColumns; ++c)
+	for (size_t c = 0; c < numColumns; ++c)
 	{
-		if(!minmaxset[c])
+		if (!minmaxset[c])
 		{
 			//column empty everywhere
 			columnSize[c] = 0;
@@ -424,7 +424,7 @@ size_t ConvertToZDW::writeLookupColumnStats(FILE* out, const size_t numColumns)
 			continue;
 		}
 
-		switch(m_ColumnType[c])
+		switch (m_ColumnType[c])
 		{
 			default: assert(!"Unrecognized type"); break;
 			case VARCHAR:
@@ -448,7 +448,7 @@ size_t ConvertToZDW::writeLookupColumnStats(FILE* out, const size_t numColumns)
 				//Determine # of bytes required to store this value.
 				val = columnMax[c] - columnMin[c];
 				columnSize[c] = 1;
-				while(val >= 256)
+				while (val >= 256)
 				{
 					++columnSize[c];
 					val /= 256;
@@ -492,21 +492,21 @@ ULONG ConvertToZDW::writeBlockRows(
 	unsigned char *setColumns = new unsigned char[numSetColumnBytes];
 
 	//Use default values of 0 for the previous row check.
-	for (k=0; k<numColumns; ++k)
+	for (k = 0; k < numColumns; ++k)
 		this->columnStoredVal[0][k].n = 0;
 
 	//Each iteration writes out one row for this block.
 	ULONG cnt = 0;
-	while(cnt < this->numRows && GetDataRow(in, m_row, this->rowColumns) > 0)
+	while (cnt < this->numRows && GetDataRow(in, m_row, this->rowColumns) > 0)
 	{
 		ULONG p = 0;
 		memset(setColumns, 0, numSetColumnBytes);
 
-		for(u = 0; u < numColumnsUsed; u++)
+		for (u = 0; u < numColumnsUsed; u++)
 		{
 			c = usedColumn[u];
 			storageBytes& storedVal = this->columnStoredVal[r][c];
-			switch(m_ColumnType[c])
+			switch (m_ColumnType[c])
 			{
 				case VARCHAR:
 				case TEXT:
@@ -516,15 +516,15 @@ ULONG ConvertToZDW::writeBlockRows(
 				case DATETIME:
 				case CHAR_2:
 				case DECIMAL:
-					if(this->rowColumns[c][0])
+					if (this->rowColumns[c][0])
 						storedVal.n = this->uniques.getOffset(this->rowColumns[c]); // - columnMin[c]; -- now hardcoded to 0
 					else
 						storedVal.n = 0;
-					if(columnStoredVal[0][c].n != columnStoredVal[1][c].n)
+					if (columnStoredVal[0][c].n != columnStoredVal[1][c].n)
 					{
 						b = 1u << (u % 8);
 						setColumns[u / 8] |= b;
-						for(j = 0; j < columnSize[c]; j++)
+						for (j = 0; j < columnSize[c]; j++)
 						{
 							rowIndexOut[p++] = storedVal.c[j];
 						}
@@ -536,11 +536,11 @@ ULONG ConvertToZDW::writeBlockRows(
 						storedVal.n += this->rowColumns[c][1] * 256; //will either be NULL or an escaped char
 						storedVal.n -= columnMin[c];
 					}
-					if(columnStoredVal[0][c].n != columnStoredVal[1][c].n)
+					if (columnStoredVal[0][c].n != columnStoredVal[1][c].n)
 					{
 						b = 1u << (u % 8);
 						setColumns[u / 8] |= b;
-						for(j = 0; j < columnSize[c]; j++)
+						for (j = 0; j < columnSize[c]; j++)
 						{
 							rowIndexOut[p++] = storedVal.c[j];
 						}
@@ -553,13 +553,13 @@ ULONG ConvertToZDW::writeBlockRows(
 					//Signed values can be stored as unsigned values
 					//as long as we flag to unpack them correctly.
 					storedVal.n = strtoull(this->rowColumns[c], NULL, 10);
-					if(storedVal.n > 0)
+					if (storedVal.n > 0)
 						storedVal.n -= columnMin[c];
-					if(columnStoredVal[0][c].n != columnStoredVal[1][c].n)
+					if (columnStoredVal[0][c].n != columnStoredVal[1][c].n)
 					{
 						b = 1u << (u % 8);
 						setColumns[u / 8] |= b;
-						for(j = 0; j < columnSize[c]; j++)
+						for (j = 0; j < columnSize[c]; j++)
 						{
 							rowIndexOut[p++] = storedVal.c[j];
 						}
@@ -583,7 +583,7 @@ ULONG ConvertToZDW::writeBlockRows(
 		r = (r ? 0 : 1);
 
 		cnt++;
-		if(!(cnt % 10000) && !this->bQuiet)
+		if (!(cnt % 10000) && !this->bQuiet)
 		{
 			printf("\r%u", cnt);
 			fflush(stdout);
@@ -651,7 +651,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 	cmd += " > ";
 	cmd += temp_outfile_name;
 	FILE *out = popen(cmd.c_str(), "w");
-	if(!out)
+	if (!out)
 	{
 		fprintf(stderr, "Could not open the process '%s' for writing!\n", cmd.c_str());
 		return FILE_CREATION_ERR;
@@ -667,14 +667,14 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		//i.e. null-terminated strings, followed by a null character, signifying the end of the column names
 		{
 			int unsigned c, n;
-			for(n=0, c=0; c < numColumns; c++) {
+			for (n = 0, c = 0; c < numColumns; c++) {
 				n += m_DWColumns[c].length() + 1; // we want the null character left at the end of each column name.
 			}
-			char *line = new char[n+1];
+			char *line = new char[n + 1];
 
-			for(n=0, c=0; c < numColumns; c++)
+			for (n = 0, c = 0; c < numColumns; c++)
 			{
-				strcpy(line+n, m_DWColumns[c].c_str());
+				strcpy(line + n, m_DWColumns[c].c_str());
 				n += m_DWColumns[c].length() + 1; //skip over null char
 			}
 			line[n++] = 0;
@@ -685,7 +685,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		//Write the column types as a byte vector of enumerated values.
 		{
 			char unsigned *temp = new char unsigned[numColumns];
-			for (int unsigned k=0; k<numColumns; ++k)
+			for (int unsigned k = 0; k < numColumns; ++k)
 				temp[k] = m_ColumnType[k];
 			assert(sizeof(char unsigned) == 1);
 			fwrite(temp, 1, numColumns, out);
@@ -696,7 +696,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		//Used for outputting an accurate table schema description.
 		{
 			short unsigned *temp = new USHORT[numColumns];
-			for (int unsigned k=0; k<numColumns; ++k)
+			for (int unsigned k = 0; k < numColumns; ++k)
 				temp[k] = static_cast<USHORT>(this->columnCharSize[k]);
 			fwrite(temp, 2, numColumns, out);
 			delete[] temp;
@@ -712,13 +712,13 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 	//the the current block will be written to the output file,
 	//and the process will repeat with a fresh block
 	//until the input file has been completely parsed.
-	ULONG cnt=0, totalCnt=0;
+	ULONG cnt = 0, totalCnt = 0;
 	ERR_CODE res = OK;
 	bool hadEnoughMemory = true;
 
 	//Maintain a list of the input files/blocks for later validation.
 	vector<string> tmp_filenames; //for validation of data that was streamed in
-	int file_pieces=0, blocks=0;
+	int file_pieces = 0, blocks = 0;
 	if (!this->bStreamingInput) {
 		//There is only one input file -- indicate it here.
 		string src_filename = filestub;
@@ -754,7 +754,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 			//Open a temp file in the output dir in order to store
 			//the data being streamed in for the second read pass.
 			assert(!this->tmp_fp);
-			tmp_filename = static_cast<char*>(malloc(strlen(zdwFile)+20));
+			tmp_filename = static_cast<char*>(malloc(strlen(zdwFile) + 20));
 			sprintf(tmp_filename, "%s.tmp.%d.gz", outfile_basepath.c_str(), file_pieces);
 			string cmd = "gzip > "; //compress the data to reduce disk writes
 			cmd += tmp_filename;
@@ -769,12 +769,12 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		}
 
 		inputStatus = parseInput(f_in);
-		switch(inputStatus)
+		switch (inputStatus)
 		{
 			case IS_DONE: hadEnoughMemory = true; break;
 			case IS_NOT_ENOUGH_MEMORY: hadEnoughMemory = false; break;
 			case IS_WRONG_NUM_OF_COLUMNS_ON_A_ROW:
-				fprintf(stderr,"\nRow %u had the problem\n", this->numRows+1); //one past the last good row
+				fprintf(stderr, "\nRow %u had the problem\n", this->numRows + 1); //one past the last good row
 				return WRONG_NUM_OF_COLUMNS_ON_A_ROW;
 		}
 		if (this->bStreamingInput) {
@@ -787,14 +787,14 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		if (!this->bQuiet)
 			printf("\r%u rows\n", this->numRows);
 
-		if(!this->numRows)
+		if (!this->numRows)
 		{
 			if (hadEnoughMemory)
 			{
 				assert(!totalCnt); //this should be during the first block
-				fprintf(stderr,"Empty data file -- nothing to process\n");
+				fprintf(stderr, "Empty data file -- nothing to process\n");
 			} else {
-				fprintf(stderr,"Not enough memory to run %s\n", exeName);
+				fprintf(stderr, "Not enough memory to run %s\n", exeName);
 				res = OUT_OF_MEMORY;
 				goto Done;
 			}
@@ -858,19 +858,19 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 			++file_pieces;
 		}
 		total_rows += this->numRows;
-	} while(!hadEnoughMemory);
+	} while (!hadEnoughMemory);
 
 	//Done writing out the ZDW file.
 	pclose(out);
 	out = NULL;
 
-	if(bValidate)
+	if (bValidate)
 	{
 		//Ensure the ZDW file's output is identical to the input data.
 		assert(tmp_filenames.size() == static_cast<size_t>(file_pieces)); //if we're storing temp files, we need to validate against them all
 		const ERR_CODE eValid = validate(temp_outfile_name.c_str(), tmp_filenames, exeName, outputDir);
 
-		if(eValid == OK)
+		if (eValid == OK)
 		{
 			if (!this->bQuiet)
 				printf("%s GOOD\n", zdwFile);
@@ -888,7 +888,7 @@ Done:
 		pclose(out);
 	//Delete the temp files created during streaming input.
 	if (this->bStreamingInput) {
-		for (size_t i=0; i<tmp_filenames.size(); ++i)
+		for (size_t i = 0; i < tmp_filenames.size(); ++i)
 			unlink(tmp_filenames[i].c_str());
 	}
 
@@ -942,7 +942,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::convertFile(
 	//Input is an .sql dump file.
 	strcpy(filestub, infile);
 	char* pos = strstr(filestub, ".sql");
-	if(pos) {
+	if (pos) {
 		*pos = 0;
 	} else {
 		return MISSING_SQL_FILE;
@@ -951,7 +951,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::convertFile(
 	//Read .desc file.
 	sprintf(command, "%s.desc.%s", filestub, getInputFileExtension());
 	in = fopen(command, "r");
-	if(!in)
+	if (!in)
 		return MISSING_DESC_FILE;
 
 	const int unsigned numColumns = ReadDescFile(in);
@@ -978,7 +978,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::convertFile(
 	} else {
 		sprintf(command, "%s.%s", filestub, getInputFileExtension());
 		in = fopen(command, "r");
-		if(!in)
+		if (!in)
 			return MISSING_SQL_FILE; //couldn't read file
 	}
 

--- a/cplusplus/ConvertToZDW.cpp
+++ b/cplusplus/ConvertToZDW.cpp
@@ -24,6 +24,8 @@
 #include <unistd.h>
 
 using std::strchr;
+using std::string;
+using std::vector;
 
 //version 4  -- multi-block support in a single file
 //version 4a -- streaming validation + quiet mode

--- a/cplusplus/ConvertToZDW.h
+++ b/cplusplus/ConvertToZDW.h
@@ -61,7 +61,7 @@ public:
 	};
 	static const char ERR_CODE_TEXTS[ERR_CODE_COUNT][30];
 
-	ConvertToZDW(const bool bQuiet=false, const bool bStreamingInput=false)
+	ConvertToZDW(const bool bQuiet = false, const bool bStreamingInput = false)
 		: compressor(GZIP)
 		, numRows(0)
 		, m_row(NULL)
@@ -71,7 +71,7 @@ public:
 		, bTrimTrailingSpaces(false)
 		, bStreamingInput(bStreamingInput)
 		, tmp_fp(NULL)
-	{}
+	{ }
 	~ConvertToZDW()
 	{
 		delete[] m_row;
@@ -79,17 +79,17 @@ public:
 		delete[] columnSize;
 	}
 
-	void trimTrailingSpaces(bool val=true) {bTrimTrailingSpaces = val;}
-	const char* getInputFileExtension() const {return "sql";}
+	void trimTrailingSpaces(bool val = true) { bTrimTrailingSpaces = val; }
+	const char* getInputFileExtension() const { return "sql"; }
 
 	ERR_CODE convertFile(const char* infile, const char* exeName,
-		const bool bValidate, char* filestub, const char* outputDir=NULL, const char* zArgs=NULL);
+		const bool bValidate, char* filestub, const char* outputDir = NULL, const char* zArgs = NULL);
 
 	Compressor compressor;
 
 private:
 	const char* getExtensionForCompressor() {
-		switch(compressor) {
+		switch (compressor) {
 			case GZIP:
 				return ".gz";
 			case BZIP2:
@@ -102,7 +102,7 @@ private:
 	}
 
 	const char* getCompressionCommand() {
-		switch(compressor) {
+		switch (compressor) {
 			case GZIP:
 				return "gzip";
 			case BZIP2:
@@ -129,11 +129,11 @@ private:
 
 	INPUT_STATUS parseInput(FILE* in);
 	ERR_CODE processFile(FILE* in, const char* filestub, const size_t numColumns,
-			const bool bValidate, const char* exeName, const char* outputDir=NULL, const char* zArgs=NULL);
+			const bool bValidate, const char* exeName, const char* outputDir = NULL, const char* zArgs = NULL);
 	int unsigned ReadDescFile(FILE* f);
 
 	ERR_CODE validate(const char* zdwFile, const std::vector<std::string>& src_filenames,
-		const char* exeName, const char* outputDir=NULL);
+		const char* exeName, const char* outputDir = NULL);
 
 	ULONG numRows;
 

--- a/cplusplus/ConvertToZDW.h
+++ b/cplusplus/ConvertToZDW.h
@@ -17,8 +17,7 @@
 
 #include <string>
 #include <vector>
-using std::string;
-using std::vector;
+
 
 //************************************************
 class ConvertToZDW
@@ -116,7 +115,7 @@ private:
 	}
 
 
-	size_t GetDataRow(FILE* f, char *&row, vector<char*>& rowColumns);
+	size_t GetDataRow(FILE* f, char *&row, std::vector<char*>& rowColumns);
 	ULONG writeBlockRows(FILE* in, FILE* out,
 		const size_t numColumns, const size_t numColumnsUsed);
 	size_t writeLookupColumnStats(FILE* out, const size_t numColumns);
@@ -133,14 +132,14 @@ private:
 			const bool bValidate, const char* exeName, const char* outputDir=NULL, const char* zArgs=NULL);
 	int unsigned ReadDescFile(FILE* f);
 
-	ERR_CODE validate(const char* zdwFile, const vector<string>& src_filenames,
+	ERR_CODE validate(const char* zdwFile, const std::vector<std::string>& src_filenames,
 		const char* exeName, const char* outputDir=NULL);
 
 	ULONG numRows;
 
-	vector<std::string> m_DWColumns;
-	vector<char unsigned> m_ColumnType;
-	vector<int> columnCharSize; //# of characters in the data type
+	std::vector<std::string> m_DWColumns;
+	std::vector<char unsigned> m_ColumnType;
+	std::vector<int> columnCharSize; //# of characters in the data type
 	char *m_row;
 
 	USHORT m_Version;
@@ -148,14 +147,14 @@ private:
 
 	Dictionary uniques;
 
-	vector<char*> rowColumns;
+	std::vector<char*> rowColumns;
 	char unsigned *minmaxset;
-	vector<ULONGLONG> columnMin;
-	vector<ULONGLONG> columnMax;
+	std::vector<ULONGLONG> columnMin;
+	std::vector<ULONGLONG> columnMax;
 	char unsigned *columnSize;
-	vector<ULONGLONG> columnVal;
-	vector<storageBytes> columnStoredVal[2];
-	vector<short> usedColumn;
+	std::vector<ULONGLONG> columnVal;
+	std::vector<storageBytes> columnStoredVal[2];
+	std::vector<short> usedColumn;
 
 	const bool bQuiet; //quiet running (no progress output messages)
 	bool bTrimTrailingSpaces;

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -270,7 +270,7 @@ size_t UnconvertFromZDW_Base::llutoa(ULONGLONG value)
 	{
 		rem    = value % 10;
 		value /= 10;
-		this->temp_buf[--pos] = (char)(rem + 0x30); //+ '0'
+		this->temp_buf[--pos] = static_cast<char>(rem + 0x30); //+ '0'
 	} while (value != 0);
 
 	return TEMP_BUF_LAST_POS - pos;
@@ -293,7 +293,7 @@ size_t UnconvertFromZDW_Base::lltoa(SLONGLONG value)
 	{
 		rem    = value % 10;
 		value /= 10;
-		this->temp_buf[--pos] = (char)(rem + 0x30); //+ '0'
+		this->temp_buf[--pos] = static_cast<char>(rem + 0x30); //+ '0'
 	} while (value != 0);
 
 	if (bMinus) //sign goes at beginning
@@ -694,7 +694,7 @@ void UnconvertFromZDW_Base::readLineLength()
 		}
 	}
 	if (this->bShowBasicStatisticsOnly) {
-		fprintf(this->statusOutput, "Max line length = %lu\n", (long unsigned)this->exportFileLineLength);
+		fprintf(this->statusOutput, "Max line length = %lu\n", static_cast<long unsigned>(this->exportFileLineLength));
 	}
 }
 
@@ -866,7 +866,7 @@ void UnconvertFromZDW_Base::readColumnFieldStats()
 		}
 	}
 	assert(numColumnsUsedFromExportFile <= this->numColumnsInExportFile);
-	this->numSetColumns = (long)ceil(numColumnsUsedFromExportFile / 8.0);
+	this->numSetColumns = static_cast<long>(ceil(numColumnsUsedFromExportFile / 8.0));
 	this->setColumns = new unsigned char[this->numSetColumns];
 	this->columnVal = new storageBytes[this->numColumns];
 	memset(this->columnVal, 0, this->numColumns * sizeof(storageBytes));
@@ -921,7 +921,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 		}
 	}
 	if (this->bShowBasicStatisticsOnly)
-		fprintf(this->statusOutput, "File version %d\n", (int)this->version);
+		fprintf(this->statusOutput, "File version %d\n", static_cast<int>(this->version));
 
 	//3. Parse column names.
 	this->columnNames.clear();
@@ -1228,7 +1228,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::readNextRow(T& buffer)
 						if (this->version >= 5) {
 							//Deserialize character text (possibly an escaped character sequence).
 							const ULONGLONG chartuple = val.n + this->columnBase[c];
-							temp[0] = (char)chartuple;
+							temp[0] = static_cast<char>(chartuple);
 							if (temp[0] != '\\') {
 								if (!temp[0]) //there's an empty field for this column-row
 									outputDefault(buffer, this->columnType[c]);
@@ -1236,12 +1236,12 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::readNextRow(T& buffer)
 									buffer.write(temp, 1);
 							} else {
 								//Output escaped character (e.g. "\\\t")
-								temp[1] = (char)(chartuple / 256);
+								temp[1] = static_cast<char>(chartuple / 256);
 								buffer.write(temp, 2);
 							}
 						} else {
 							//Before version 5, the converter included no more than one byte per char field.
-							temp[0] = (char)val.n;
+							temp[0] = static_cast<char>(val.n);
 							buffer.write(temp, 1);
 						}
 					} else {

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -27,6 +27,8 @@ using std::ostream;
 using namespace ZDW;
 using std::map;
 using std::set;
+using std::string;
+using std::vector;
 
 //version 4  -- added support for multiple blocks in a single file
 //version 4a -- streaming uncompression

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -81,9 +81,9 @@ char const * const VIRTUAL_EXPORT_BASENAME_COLUMN_NAME = "virtual_export_basenam
 char const * const VIRTUAL_EXPORT_ROW_COLUMN_NAME = "virtual_export_row";
 
 namespace {
-    string getInputFilename(string filename) {
-	    return !filename.empty() ? filename : string("stdin");
-    }
+	string getInputFilename(string filename) {
+		return !filename.empty() ? filename : string("stdin");
+	}
 
  /*
   * In: inFileName
@@ -106,14 +106,14 @@ namespace {
 			const string buf = "./" + inFileNameStr;
 			sourceDir = strdup(buf.c_str());
 			sourceDir[1] = 0;
-			filestub_local = sourceDir+2;
+			filestub_local = sourceDir + 2;
 		}
 
 		//Modify input filestub: cut off the final ".zdw*" for naming the output file(s).
 		char *pos = strstr(filestub_local, ".zdw");
 		while (pos) {
 			//Look for another ".zdw"
-			char *nextPos = strstr(pos+4, ".zdw");
+			char *nextPos = strstr(pos + 4, ".zdw");
 			if (nextPos)
 				pos = nextPos;
 			else {
@@ -366,7 +366,7 @@ bool UnconvertFromZDW_Base::setNamesOfColumnsToOutput(
 	const string delimiters = ", ";
 
 	// Skip delimiters at beginning.
-    string::size_type lastPos = csv_str.find_first_not_of(delimiters, 0);
+	string::size_type lastPos = csv_str.find_first_not_of(delimiters, 0);
 
 	// Find first "non-delimiter".
 	string::size_type pos = csv_str.find_first_of(delimiters, lastPos);
@@ -428,7 +428,7 @@ bool UnconvertFromZDW_Base::setNamesOfColumnsToOutput(
 	}
 
 	int unsigned index = 0;
-	for(vector<string>::const_iterator itr=csv_vector.begin(); itr!=csv_vector.end(); itr++)
+	for (vector<string>::const_iterator itr = csv_vector.begin(); itr != csv_vector.end(); itr++)
 	{
 		// Add column name to the map.
 		const string& column_name = *itr;
@@ -478,7 +478,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::outputDescToStdOut(
 	const vector<string>& columnNames)
 {
 	FILE *out = stdout;
-	if(!out)
+	if (!out)
 	{
 		fprintf(stderr, "%s: Could not open STDOUT for writing\n", exeName.c_str());
 		return FILE_CREATION_ERR;
@@ -516,7 +516,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::GetSchema(
 	vector<string>::const_iterator strIt;
 	vector<string>::const_iterator begin = outColumnTexts.begin();
 	for (strIt = begin; strIt != outColumnTexts.end(); ++strIt) {
-		if(strIt != begin) {
+		if (strIt != begin) {
 			stream << ",\n";
 		}
 		stream << *strIt;
@@ -538,7 +538,7 @@ string UnconvertFromZDW_Base::GetBaseNameForInFile(const string &inFileName) {
 	// Must get the value of outputBaseName *before* we deallocate sourceDir since the
 	// character buffer used for outputBasename will be freed when we free sourceDir.
 	const string inFileBaseName = outputBasename;
-	if(sourceDir)
+	if (sourceDir)
 		free(sourceDir);
 	return inFileBaseName;
 }
@@ -550,7 +550,7 @@ vector<string> UnconvertFromZDW_Base::getDesc(const vector<string>& columnNames,
 	const ULONG numColumns = columnNames.size();
 	const ULONG numOutputColumns = numColumns + this->blankColumnNames.size();
 	vector<string> outColumnTexts(numOutputColumns);
-	for(size_t c = 0; c < numColumns; c++)
+	for (size_t c = 0; c < numColumns; c++)
 	{
 		const int outColumnIndex = this->namesOfColumnsToOutput.empty() ? c : this->outputColumns[c];
 		if (outColumnIndex != IGNORE) //only list columns that are being outputted
@@ -567,7 +567,7 @@ vector<string> UnconvertFromZDW_Base::getDesc(const vector<string>& columnNames,
 	}
 
 	//When requesting absent columns for padding, give them a generic text type.
-	for (map<int, string>::const_iterator iter=this->blankColumnNames.begin(); iter!=this->blankColumnNames.end(); ++iter)
+	for (map<int, string>::const_iterator iter = this->blankColumnNames.begin(); iter != this->blankColumnNames.end(); ++iter)
 	{
 		outColumnTexts[iter->first] =
 			getColumnDesc(iter->second, TEXT, size_t(-1), name_type_separator, delimiter);
@@ -583,7 +583,7 @@ string UnconvertFromZDW_Base::getColumnDesc(const string& name, UCHAR type, size
 	string text = name;
 	text += name_type_separator;
 
-	switch(type)
+	switch (type)
 	{
 		case VIRTUAL_EXPORT_FILE_BASENAME:
 		case VARCHAR:
@@ -624,7 +624,7 @@ string UnconvertFromZDW_Base::getColumnDesc(const string& name, UCHAR type, size
 void UnconvertFromZDW_Base::cleanupBlock()
 {
 	//Deinit for this block.
-	for (size_t i=0; i<this->dictionary.size(); ++i)
+	for (size_t i = 0; i < this->dictionary.size(); ++i)
 		delete[] this->dictionary[i];
 	delete[] this->uniques;
 	delete[] this->visitors;
@@ -655,8 +655,8 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::parseBlockHeader()
 	assert(!this->columnBase);
 	assert(!this->columnVal);
 
-	assert(sizeof(UCHAR)==1);
-	assert(sizeof(USHORT)==2);
+	assert(sizeof(UCHAR) == 1);
+	assert(sizeof(USHORT) == 2);
 
 	readLineLength();
 
@@ -674,8 +674,8 @@ void UnconvertFromZDW_Base::readLineLength()
 	{
 		//Each block stores this header info.
 		readBytes(&this->numLines, 4);
-		if (this->version>=6) {
-			assert(sizeof(this->exportFileLineLength)==4);
+		if (this->version >= 6) {
+			assert(sizeof(this->exportFileLineLength) == 4);
 			readBytes(&this->exportFileLineLength, 4);
 		} else {
 			// Before version 6, the format only allowed a 2-byte length field.
@@ -683,7 +683,7 @@ void UnconvertFromZDW_Base::readLineLength()
 			// and storing it in the properly sized variable.
 			USHORT t_version;
 			readBytes(&t_version, 2);
-			this->exportFileLineLength=t_version;
+			this->exportFileLineLength = t_version;
 		}
 		readBytes(&this->lastBlock, 1);
 
@@ -749,18 +749,18 @@ void UnconvertFromZDW_Base::readDictionary()
 			this->uniques[0].m_Char.n = 0;
 			this->uniques[0].m_PrevChar.n = 0;
 			unsigned int c;
-			for(c = 1; c <= this->dictionarySize; c++)
+			for (c = 1; c <= this->dictionarySize; c++)
 			{
 				readBytes(this->uniques[c].m_Char.c, BLOCKSIZE);
 				readBytes(this->uniques[c].m_PrevChar.c, indexSize);
-				if(this->bShowStatus && !(c % OUTPUT_MOD))
+				if (this->bShowStatus && !(c % OUTPUT_MOD))
 				{
-					fprintf(this->statusOutput, "\r%u", c-1);
+					fprintf(this->statusOutput, "\r%u", c - 1);
 					fflush(this->statusOutput);
 				}
 			}
 			if (this->bShowStatus && indexSize != 0)
-				fprintf(this->statusOutput, "\r%u\n", c-1);
+				fprintf(this->statusOutput, "\r%u\n", c - 1);
 		}
 	}
 
@@ -779,7 +779,7 @@ void UnconvertFromZDW_Base::readDictionaryChunk(const size_t size)
 	size_t bytesToStitch = 0;
 	const size_t numChunks = this->dictionary.size();
 	if (numChunks) {
-		const size_t prevChunk = numChunks-1;
+		const size_t prevChunk = numChunks - 1;
 		const char *endOfBlock = this->dictionary[prevChunk] + this->dictionary_memblock_size[prevChunk] - 1;
 		textToStitch = endOfBlock;
 		while (*textToStitch)
@@ -794,7 +794,7 @@ void UnconvertFromZDW_Base::readDictionaryChunk(const size_t size)
 	if (bytesToStitch) {
 		//Move partial entry from end of previous block to new block.
 		strcpy(chunk, textToStitch);
-		this->dictionary_memblock_size[numChunks-1] -= bytesToStitch;
+		this->dictionary_memblock_size[numChunks - 1] -= bytesToStitch;
 	}
 
 	readBytes(chunk + bytesToStitch, size);
@@ -833,11 +833,11 @@ void UnconvertFromZDW_Base::readVisitorDictionary()
 			this->visitors[0].m_VID = 0;
 			this->visitors[0].m_PrevID.n = 0;
 			unsigned int c;
-			for(c = 1; c <= this->numVisitors; c++)
+			for (c = 1; c <= this->numVisitors; c++)
 			{
 				readBytes(&(this->visitors[c].m_VID), 8);
 				readBytes(this->visitors[c].m_PrevID.c, vIndexSize);
-				if(this->bShowStatus && !(c % OUTPUT_MOD))
+				if (this->bShowStatus && !(c % OUTPUT_MOD))
 				{
 					fprintf(this->statusOutput, "\r%u", c - 1);
 					fflush(this->statusOutput);
@@ -855,11 +855,11 @@ void UnconvertFromZDW_Base::readColumnFieldStats()
 	readBytes(this->columnSize, this->numColumnsInExportFile);
 	this->columnBase = new ULONGLONG[this->numColumns];
 	ULONG numColumnsUsedFromExportFile = 0;
-	for(unsigned int c = 0; c < this->numColumnsInExportFile; ++c)
+	for (unsigned int c = 0; c < this->numColumnsInExportFile; ++c)
 	{
-		if(this->columnSize[c])
+		if (this->columnSize[c])
 		{
-			readBytes(this->columnBase+c, 8);
+			readBytes(this->columnBase + c, 8);
 			++numColumnsUsedFromExportFile;
 		} else {
 			this->columnBase[c] = 0;
@@ -926,13 +926,13 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 	//3. Parse column names.
 	this->columnNames.clear();
 	readBytes(row, 1);
-	while(row[0])
+	while (row[0])
 	{
 		size_t p = 0;
 		do {
 			readBytes(&(row[++p]), 1);
 		}
-		while(row[p]);
+		while (row[p]);
 		this->columnNames.push_back(row);
 		readBytes(row, 1); //pass null terminator
 	}
@@ -963,13 +963,13 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 
 	//Case-insensitive matching
 	map<string, int unsigned, InsensitiveCompare> columnsCopy;
-	for (map<string, int unsigned>::const_iterator it=this->namesOfColumnsToOutput.begin();
-			it!=this->namesOfColumnsToOutput.end(); ++it)
+	for (map<string, int unsigned>::const_iterator it = this->namesOfColumnsToOutput.begin();
+			it != this->namesOfColumnsToOutput.end(); ++it)
 		columnsCopy[it->first] = it->second;
 
 	//Scan the columns in the file.
 	int unsigned outIndex = 0;
-	for (int unsigned index=0; index<this->numColumns; ++index)
+	for (int unsigned index = 0; index < this->numColumns; ++index)
 	{
 		//Do we have an explicit inclusion/exclusion for this column?
 		map<string, int unsigned>::iterator findIt = columnsCopy.find(this->columnNames[index]);
@@ -1001,7 +1001,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 		//  then we will fill in the missing indexes with blank values.
 		if (this->bOutputEmptyMissingColumns) {
 			//Identify which column names aren't in the file.
-			for (map<string, int unsigned>::const_iterator iter=columnsCopy.begin();
+			for (map<string, int unsigned>::const_iterator iter = columnsCopy.begin();
 				iter != columnsCopy.end(); ++iter)
 			{
 				this->blankColumnNames[iter->second] = iter->first;
@@ -1016,7 +1016,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 			//EX:
 			//    Given a sequence of existing output column positioning of [2,1,3,5],
 			//    we compact the set of values, resulting in the sequence [1,0,2,3], which contains no gaps.
-			int unsigned nextIndex=0;
+			int unsigned nextIndex = 0;
 			for (map<int unsigned, int unsigned>::const_iterator valIter = encounteredValues.begin();
 					valIter != encounteredValues.end(); ++valIter, ++nextIndex)
 			{
@@ -1065,7 +1065,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 template <typename T>
 void UnconvertFromZDW<T>::outputDefault(T& buffer, const UCHAR type)
 {
-	switch(type)
+	switch (type)
 	{
 		case CHAR:
 		case VARCHAR:
@@ -1142,7 +1142,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::readNextRow(T& buffer)
 			if (this->columnSize[c])
 			{
 				storageBytes& val = this->columnVal[c];
-				if(this->setColumns[u / 8] & (1u << (u % 8))) //is the bit for this column set?
+				if (this->setColumns[u / 8] & (1u << (u % 8))) //is the bit for this column set?
 				{
 					//This column's value is different from that of the previous row,
 					//so we need to read the new value to stay current in the data stream.
@@ -1310,34 +1310,34 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 		fprintf(this->statusOutput, "Reading %u rows\n", this->numLines);
 
 	//Show compression statistics when both test and statistics modes are set.
-	ULONGLONG equalityBitsSet=0;
+	ULONGLONG equalityBitsSet = 0;
 	vector<ULONG> equalityBitsInColumn(this->numSetColumns * 8, 0);
 
 	//If testing, or showing stats, don't actually uncompress any data.
 	if (this->bTestOnly ||
 		//when showing stats, note we only need to scan through this block if there is another one following
-		(this->bShowBasicStatisticsOnly && !isLastBlock()) )
+		(this->bShowBasicStatisticsOnly && !isLastBlock()))
 	{
 		ULONG index;
 
 		//Read in the data and ensure lookup indices are valid, but output nothing.
 		//This code should mirror the read format of the non-test code below.
-		while(this->rowsRead < this->numLines && !isFinished())
+		while (this->rowsRead < this->numLines && !isFinished())
 		{
 			//Process a row.
 			readBytes(this->setColumns, this->numSetColumns); //bit flags -- are fields same as last row?
 
 			long u = 0;
-			for(size_t c = 0; c < this->numColumnsInExportFile; ++c)
+			for (size_t c = 0; c < this->numColumnsInExportFile; ++c)
 			{
 				if (this->columnType[c] == VISID_LOW)
 					continue; //handled along with the adjacent VISID_HIGH column
 
-				if(!this->columnSize[c])
+				if (!this->columnSize[c])
 					continue;
 
 				storageBytes& val = this->columnVal[c];
-				if(this->setColumns[u / 8] & (1u << (u % 8))) //is the bit for this column set?
+				if (this->setColumns[u / 8] & (1u << (u % 8))) //is the bit for this column set?
 				{
 					//This column's value is different from that of the previous row,
 					//so read the new value.
@@ -1352,7 +1352,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 
 				//Validate the field code.
 				if (this->bTestOnly) {
-					switch(this->columnType[c])
+					switch (this->columnType[c])
 					{
 						case VIRTUAL_EXPORT_FILE_BASENAME: assert(!"VIRTUAL_EXPORT_FILE_BASENAME should only get default value"); break;
 						case VISID_LOW: assert(!"VISID_LOW should be skipped"); break;
@@ -1363,7 +1363,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 						case LONGTEXT:
 						case DATETIME:
 						case CHAR_2:
-							if(val.n)
+							if (val.n)
 							{
 								index = val.n + this->columnBase[c];
 								if (index > this->dictionarySize)
@@ -1403,7 +1403,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 		//Normal parsing and output of the data.
 
 		//Each iteration processes one row.
-		while(this->rowsRead < this->numLines && !isFinished())
+		while (this->rowsRead < this->numLines && !isFinished())
 		{
 			//Process a row.
 			eRet = readNextRow(buffer);
@@ -1411,7 +1411,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 				return eRet;
 
 			//Progress.
-			if(this->bShowStatus && !(this->rowsRead % 10000))
+			if (this->bShowStatus && !(this->rowsRead % 10000))
 			{
 				fprintf(this->statusOutput, "\r%u", this->rowsRead);
 				fflush(this->statusOutput);
@@ -1419,7 +1419,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 		}
 
 		//Final progress for this block.
-		if(this->bShowStatus)
+		if (this->bShowStatus)
 			fprintf(this->statusOutput, "\r%u\n", this->rowsRead);
 	}
 
@@ -1437,8 +1437,8 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 	//Optional compression characteristic display
 	if (equalityBitsSet) {
 		size_t nonEmptyColumns = 0;
-		for(size_t c = 0; c < this->numColumnsInExportFile; ++c) {
-			if(this->columnSize[c])
+		for (size_t c = 0; c < this->numColumnsInExportFile; ++c) {
+			if (this->columnSize[c])
 				++nonEmptyColumns;
 		}
 
@@ -1447,7 +1447,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 			this->numLines, this->numColumnsInExportFile, this->numSetColumns,
 			nonEmptyColumns, nonEmptyColumns*100/float(this->numColumnsInExportFile));
 
-		for (size_t c=0; c<nonEmptyColumns; ++c) {
+		for (size_t c = 0; c < nonEmptyColumns; ++c) {
 			fprintf(this->statusOutput, "%u ", equalityBitsInColumn[c]);
 		}
 		fprintf(this->statusOutput, "\n");
@@ -1543,7 +1543,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 	{
 		char textbuf[1024];
 		sprintf(textbuf, "%s/%s%s", outputDir, outputBasename, ext ? ext : "");
-		if(this->bShowStatus)
+		if (this->bShowStatus)
 			fprintf(this->statusOutput, "Writing %s\n", textbuf);
 		//Open output stream.
 		if (bStdout) {
@@ -1551,7 +1551,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 		} else {
 			this->out = fopen(textbuf, "w");
 		}
-		if(!this->out)
+		if (!this->out)
 		{
 			fprintf(stderr, "%s: Could not open %s for writing\n", this->exeName.c_str(), textbuf);
 			eRet = FILE_CREATION_ERR;
@@ -1584,7 +1584,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 			memcpy(&all_output_columns[0], this->outputColumns, num_output_columns * sizeof(int));
 			//If there are blank columns, define them at the end of the input buffer, each outputting to its specified position in the column list.
 			size_t index = this->numColumns;
-			for (map<int, string>::const_iterator iter=this->blankColumnNames.begin(); iter!=this->blankColumnNames.end(); ++iter)
+			for (map<int, string>::const_iterator iter = this->blankColumnNames.begin(); iter != this->blankColumnNames.end(); ++iter)
 			{
 				all_output_columns[index++] = iter->first;
 			}
@@ -1623,9 +1623,9 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 
 Done:
 	//Clean-up.
-	if(sourceDir)
+	if (sourceDir)
 		free(sourceDir);
-	if(outputDir)
+	if (outputDir)
 		free(outputDir);
 	if (this->out && !bStdout)
 		fclose(this->out);
@@ -1694,7 +1694,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(char ** buffer,
 						return ROW_COUNT_ERR; //premature exit (truncated file?)
 
 					//Process and return a row.
-					if(!bUseInternalBuffer)
+					if (!bUseInternalBuffer)
 					{
 						this->pBufferedOutput->setOutputBuffer(buffer, size);
 					}
@@ -1702,7 +1702,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(char ** buffer,
 					this->pBufferedOutput->setOutputColumnPtrs(outColumns);
 					ERR_CODE eRet = readNextRow(*this->pBufferedOutput);
 					ERR_CODE eRetForNumColumns = this->getNumOutputColumns(numColumns);
-					if(eRetForNumColumns != OK)
+					if (eRetForNumColumns != OK)
 						numColumns = 0;
 					return eRet;
 				} else {
@@ -1779,7 +1779,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::handleZDWParseBlockHea
 
 	assert(!this->pBufferedOutput.get());
 	this->pBufferedOutput.reset(new BufferedOutputInMem(this->exportFileLineLength + this->virtualLineLength + 1, bUseInternalBuffer));
-	if(this->namesOfColumnsToOutput.empty())
+	if (this->namesOfColumnsToOutput.empty())
 	{
 		//So getNumOutputColumns works in this use case
 		pBufferedOutput->SetNumOutputColumns(this->numColumns);
@@ -1789,7 +1789,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::handleZDWParseBlockHea
 		memcpy(&all_output_columns[0], this->outputColumns, num_output_columns * sizeof(int));
 		//If there are blank columns, define them at the end of the input buffer, each outputting to its specified position in the column list.
 		size_t index = this->numColumns;
-		for (map<int, string>::const_iterator iter=this->blankColumnNames.begin(); iter!=this->blankColumnNames.end(); ++iter)
+		for (map<int, string>::const_iterator iter = this->blankColumnNames.begin(); iter != this->blankColumnNames.end(); ++iter)
 		{
 			all_output_columns[index++] = iter->first;
 		}
@@ -1809,7 +1809,7 @@ void UnconvertFromZDWToMemory::getColumnNamesVector(vector<string> &columnNamesV
 
 	OutputOrderIndexer *pOutputOrderIndexer = new OutputOrderIndexer[numOutputColumns];
 	int validNumColumns = 0;
-	for(size_t c = 0; c < numColumns; c++)
+	for (size_t c = 0; c < numColumns; c++)
 	{
 		const int outColumnIndex = this->namesOfColumnsToOutput.empty() ? c : this->outputColumns[c];
 		if (outColumnIndex == IGNORE)
@@ -1824,20 +1824,20 @@ void UnconvertFromZDWToMemory::getColumnNamesVector(vector<string> &columnNamesV
 	}
 
 	//When requesting absent columns for padding, give them a generic text type.
-	for (map<int, string>::const_iterator iter=this->blankColumnNames.begin(); iter!=this->blankColumnNames.end(); ++iter)
+	for (map<int, string>::const_iterator iter = this->blankColumnNames.begin(); iter != this->blankColumnNames.end(); ++iter)
 	{
 		// if index is a negative number, get the column name from blankColumnNames
-		pOutputOrderIndexer[validNumColumns].index = -1*(iter->first) - 1; //ensure negative value to differentiate
+		pOutputOrderIndexer[validNumColumns].index = -1 * (iter->first) - 1; //ensure negative value to differentiate
 		pOutputOrderIndexer[validNumColumns].outputIndex = iter->first;
 		validNumColumns++;
 	}
 
 	qsort(pOutputOrderIndexer, validNumColumns, sizeof(OutputOrderIndexer), compareByOutputIndex);
 
-	for(int i=0; i<validNumColumns; i++)
+	for (int i = 0; i < validNumColumns; i++)
 	{
 		if (pOutputOrderIndexer[i].index < 0) {
-			columnNamesVector.push_back(blankColumnNames[(pOutputOrderIndexer[i].index+1) * -1]);
+			columnNamesVector.push_back(blankColumnNames[(pOutputOrderIndexer[i].index + 1) * -1]);
 		} else {
 			columnNamesVector.push_back(columnNames[pOutputOrderIndexer[i].index]);
 		}
@@ -1857,7 +1857,7 @@ bool UnconvertFromZDWToMemory::OutputDescToFile(const string &outputDir)
 	const char* outputBasename = NULL;
 	InitDirAndBasenameFromFileName(this->inFileName, sourceDir, outputBasename);
 	ERR_CODE eRet = this->outputDescToFile(this->columnNames, outputDir.c_str(), outputBasename, ".sql");
-	if(sourceDir)
+	if (sourceDir)
 		free(sourceDir);
 	return eRet == OK;
 }

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -83,11 +83,11 @@ namespace {
 	    return !filename.empty() ? filename : string("stdin");
     }
 
- /* 
+ /*
   * In: inFileName
   * Out: sourceDir & basename (a pointer into the allocated sourceDir buffer)
   * The caller needs to free the memory pointed to by sourceDir, after all references to basename.
-  */	 
+  */
 	void InitDirAndBasenameFromFileName(string const& inFileNameStr, char * &sourceDir, const char* &basename)
 	{
 		char *filestub_local = NULL;
@@ -193,7 +193,7 @@ UnconvertFromZDW_Base::UnconvertFromZDW_Base(const string &fileName,
 				//Internal uncompression of .gz files.
 				input = new BufferedInput(inFileName.c_str(), 16*1024, true);
 				return;
-			} 
+			}
 			if (len >= 5 && !strcmp(inFileName.c_str() + len - 4, ".bz2")) {
 				//Streaming uncompression of .bz2 files.
 				cmd = "bzip2 -d --stdout ";
@@ -411,7 +411,7 @@ bool UnconvertFromZDW_Base::setNamesOfColumnsToOutput(
 }
 
 bool UnconvertFromZDW_Base::setNamesOfColumnsToOutput(
-	const vector<string> &csv_vector, 
+	const vector<string> &csv_vector,
 	ZDW::COLUMN_INCLUSION_RULE inclusionRule)
 {
 	this->namesOfColumnsToOutput.clear(); //start empty
@@ -524,12 +524,12 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::GetSchema(
 }
 
 string UnconvertFromZDW_Base::GetBaseNameForInFile(const string &inFileName) {
-	
+
 	if (inFileName.empty()) {
 		//return "No Input Filename Found";
 		return string();
 	}
-	
+
 	char *sourceDir = NULL;
 	const char* outputBasename = NULL;
 	InitDirAndBasenameFromFileName(inFileName, sourceDir, outputBasename);
@@ -936,7 +936,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 	}
 
 	this->numColumnsInExportFile = this->columnNames.size();
-	
+
 	// 3b Detour To Start Setup For Virtual Columns (i.e. VIRTUAL_EXPORT_FILE_BASENAME, VIRTUAL_EXPORT_ROW_COLUMN_NAME)
 	if (UseVirtualExportBaseNameColumn()) {
 		this->indexForVirtualBaseNameColumn = this->columnNames.size();
@@ -1038,9 +1038,9 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 		this->columnCharSize = new USHORT[this->numColumns];
 		readBytes(this->columnCharSize, this->numColumnsInExportFile * 2);
 	}
-	
+
 	// 5. Finish Setup For Virtual Columns (i.e. VIRTUAL_EXPORT_FILE_BASENAME)
-	
+
 	if (UseVirtualExportBaseNameColumn()) {
 		this->columnType[this->indexForVirtualBaseNameColumn] = VIRTUAL_EXPORT_FILE_BASENAME;
 		if (this->columnCharSize) {
@@ -1696,7 +1696,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(char ** buffer,
 					{
 						this->pBufferedOutput->setOutputBuffer(buffer, size);
 					}
-					
+
 					this->pBufferedOutput->setOutputColumnPtrs(outColumns);
 					ERR_CODE eRet = readNextRow(*this->pBufferedOutput);
 					ERR_CODE eRetForNumColumns = this->getNumOutputColumns(numColumns);
@@ -1795,7 +1795,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::handleZDWParseBlockHea
 		if (!bRes)
 			return BAD_REQUESTED_COLUMN; //column ordering is bad -- don't attempt to process further.
 	}
-	
+
 	setState(ZDW_GET_NEXT_ROW);
 	return OK;
 }

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -93,25 +93,25 @@ public:
 	static const char ERR_CODE_TEXTS[ZDW::ERR_CODE_COUNT + 1][30];
 
 	UnconvertFromZDW_Base(const std::string &inFileName,
-			const bool bShowStatus=true, const bool bQuiet=true,
-			const bool bTestOnly=false, const bool bOutputDescFileOnly=false);
+			const bool bShowStatus = true, const bool bQuiet = true,
+			const bool bTestOnly = false, const bool bOutputDescFileOnly = false);
 	virtual ~UnconvertFromZDW_Base();
 
 	//Common API.
-	std::vector<std::string> getColumnNames() const {return this->columnNames;}
-	UCHAR* getColumnTypes() const {return this->columnType;}
-	ULONG getRowsRead() const {return this->rowsRead;} //in current block
-	ULONG getNumLines() const {return this->numLines;} //in current block
-	bool isLastBlock() const {return this->lastBlock != 0;}
-	bool isFinished() const {return this->input->eof();}
-	bool isReadOpen() const {return this->input && this->input->is_open();}
+	std::vector<std::string> getColumnNames() const { return this->columnNames; }
+	UCHAR* getColumnTypes() const { return this->columnType; }
+	ULONG getRowsRead() const { return this->rowsRead; } //in current block
+	ULONG getNumLines() const { return this->numLines; } //in current block
+	bool isLastBlock() const { return this->lastBlock != 0; }
+	bool isFinished() const { return this->input->eof(); }
+	bool isReadOpen() const { return this->input && this->input->is_open(); }
 
 	static void printError(const std::string &exeName, const std::string &inFileName);
 
 	ERR_CODE readHeader();
 	bool setNamesOfColumnsToOutput(const std::string& csv_str, ZDW::COLUMN_INCLUSION_RULE inclusionRule);
 	bool setNamesOfColumnsToOutput(const std::vector<std::string> &csv_vector, ZDW::COLUMN_INCLUSION_RULE inclusionRule);
-	void showBasicStatisticsOnly(bool bVal=true) {this->bShowBasicStatisticsOnly = bVal;}
+	void showBasicStatisticsOnly(bool bVal = true) { this->bShowBasicStatisticsOnly = bVal; }
 
 	ERR_CODE GetSchema(std::ostream& stream);
 
@@ -120,7 +120,7 @@ protected:
 		const char* outputDir, const char* filestub, const char* ext);
 	ERR_CODE outputDescToStdOut(const std::vector<std::string>& columnNames);
 
-	size_t readBytes(void* buf, const size_t len, const bool bHaltOnReadError=true);
+	size_t readBytes(void* buf, const size_t len, const bool bHaltOnReadError = true);
 	size_t skipBytes(const size_t len);
 	char* GetWord(ULONG index, char* row);
 
@@ -154,7 +154,7 @@ protected:
 	char *row;
 
 	static const size_t TEMP_BUF_SIZE = 512;
-	static const size_t TEMP_BUF_LAST_POS = TEMP_BUF_SIZE-1;
+	static const size_t TEMP_BUF_LAST_POS = TEMP_BUF_SIZE - 1;
 	char temp_buf[TEMP_BUF_SIZE];
 
 	std::string exeName;
@@ -200,7 +200,7 @@ protected:
 		ZDW_FINISHING,
 		ZDW_END
 	};
-	void setState(STATE state) {this->eState = state;}
+	void setState(STATE state) { this->eState = state; }
 	STATE eState;
 
 	size_t GetCurrentRowNumber() const { return currentRowNumber; }
@@ -228,8 +228,8 @@ class UnconvertFromZDW : public UnconvertFromZDW_Base
 {
 public:
 	UnconvertFromZDW(const std::string &inFileName,
-			const bool bShowStatus=true, const bool bQuiet=true,
-			const bool bTestOnly=false, const bool bOutputDescFileOnly=false)
+			const bool bShowStatus = true, const bool bQuiet = true,
+			const bool bTestOnly = false, const bool bOutputDescFileOnly = false)
 		: UnconvertFromZDW_Base(inFileName, bShowStatus, bQuiet, bTestOnly, bOutputDescFileOnly)
 	{ }
 
@@ -250,10 +250,10 @@ class UnconvertFromZDWToFile : public UnconvertFromZDW<BufferedOutput_T>
 {
 public:
 	UnconvertFromZDWToFile(const std::string &inFileName,
-			const bool bShowStatus=true, const bool bQuiet=true,
-			const bool bTestOnly=false, const bool bOutputDescFileOnly=false)
+			const bool bShowStatus = true, const bool bQuiet = true,
+			const bool bTestOnly = false, const bool bOutputDescFileOnly = false)
 		: UnconvertFromZDW<BufferedOutput_T>(inFileName, bShowStatus, bQuiet, bTestOnly, bOutputDescFileOnly)
-        , out(NULL)
+		, out(NULL)
 	{ }
 
 	ZDW::ERR_CODE unconvert(const char* exeName, const char* outputBasename, const char* ext, const char* outputDir, bool bStdout);
@@ -267,9 +267,9 @@ class UnconvertFromZDWToMemory : public UnconvertFromZDW<BufferedOutputInMem>
 public:
 	// if set bUseInternalBuffer to false, please use getRow(char ** buffer, size_t *size, char** outColumns) to get row data.
 	UnconvertFromZDWToMemory(const std::string &inFileName,
-			const bool bUseInternalBuffer=true,
-			const bool bShowStatus=true, const bool bQuiet=true,
-			const bool bTestOnly=false, const bool bOutputDescFileOnly=false)
+			const bool bUseInternalBuffer = true,
+			const bool bShowStatus = true, const bool bQuiet = true,
+			const bool bTestOnly = false, const bool bOutputDescFileOnly = false)
 		: UnconvertFromZDW<BufferedOutputInMem>(inFileName, bShowStatus, bQuiet, bTestOnly, bOutputDescFileOnly)
 		, num_output_columns(0)
 		, bUseInternalBuffer(bUseInternalBuffer)
@@ -287,7 +287,7 @@ public:
 	size_t getCurrentRowLength();
 
 	// Call getNumOutputColumns or getRow first to retrieve the actual value of line length
-	ULONG getLineLength() {return this->exportFileLineLength + this->virtualLineLength;}
+	ULONG getLineLength() { return this->exportFileLineLength + this->virtualLineLength; }
 
 	void getColumnNamesVector(std::vector<std::string> &columnNamesVector);
 	bool hasColumnName(const std::string& name) const;

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -25,10 +25,6 @@
 
 #include <boost/scoped_ptr.hpp>
 
-using std::vector;
-using std::string;
-using std::ostream;
-
 
 namespace ZDW {
 	//Error codes
@@ -102,7 +98,7 @@ public:
 	virtual ~UnconvertFromZDW_Base();
 
 	//Common API.
-	vector<string> getColumnNames() const {return this->columnNames;}
+	std::vector<std::string> getColumnNames() const {return this->columnNames;}
 	UCHAR* getColumnTypes() const {return this->columnType;}
 	ULONG getRowsRead() const {return this->rowsRead;} //in current block
 	ULONG getNumLines() const {return this->numLines;} //in current block
@@ -110,25 +106,25 @@ public:
 	bool isFinished() const {return this->input->eof();}
 	bool isReadOpen() const {return this->input && this->input->is_open();}
 
-	static void printError(const std::string &exeName, const string &inFileName);
+	static void printError(const std::string &exeName, const std::string &inFileName);
 
 	ERR_CODE readHeader();
-	bool setNamesOfColumnsToOutput(const string& csv_str, ZDW::COLUMN_INCLUSION_RULE inclusionRule);
-	bool setNamesOfColumnsToOutput(const vector<string> &csv_vector, ZDW::COLUMN_INCLUSION_RULE inclusionRule);
+	bool setNamesOfColumnsToOutput(const std::string& csv_str, ZDW::COLUMN_INCLUSION_RULE inclusionRule);
+	bool setNamesOfColumnsToOutput(const std::vector<std::string> &csv_vector, ZDW::COLUMN_INCLUSION_RULE inclusionRule);
 	void showBasicStatisticsOnly(bool bVal=true) {this->bShowBasicStatisticsOnly = bVal;}
 
-	ERR_CODE GetSchema(ostream& stream);
+	ERR_CODE GetSchema(std::ostream& stream);
 
 protected:
-	ERR_CODE outputDescToFile(const vector<string>& columnNames,
+	ERR_CODE outputDescToFile(const std::vector<std::string>& columnNames,
 		const char* outputDir, const char* filestub, const char* ext);
-	ERR_CODE outputDescToStdOut(const vector<string>& columnNames);
+	ERR_CODE outputDescToStdOut(const std::vector<std::string>& columnNames);
 
 	size_t readBytes(void* buf, const size_t len, const bool bHaltOnReadError=true);
 	size_t skipBytes(const size_t len);
 	char* GetWord(ULONG index, char* row);
 
-	static string GetBaseNameForInFile(const std::string &inFileName);
+	static std::string GetBaseNameForInFile(const std::string &inFileName);
 	bool UseVirtualExportBaseNameColumn() const;
 	void EnableVirtualExportBaseNameColumn();
 
@@ -143,8 +139,8 @@ protected:
 
 	ULONG exportFileLineLength;
 	ULONG virtualLineLength;
-	vector<char *> dictionary; //version 9+
-	vector<ULONG> dictionary_memblock_size;
+	std::vector<char *> dictionary; //version 9+
+	std::vector<ULONG> dictionary_memblock_size;
 	UniquesPart *uniques;  //version 1-8
 	VisitorPart *visitors; //version 1-7
 
@@ -163,7 +159,7 @@ protected:
 
 	std::string exeName;
 	const std::string inFileName;
-	const string inFileBaseName;
+	const std::string inFileBaseName;
 
 	BufferedInput *input;
 
@@ -172,18 +168,18 @@ protected:
 	const bool bTestOnly;          //if set, only validate that data appear to be good without unconverting
 	bool bShowBasicStatisticsOnly; //if set, show header statistics of data and exit
 	bool bFailOnInvalidColumns; //if invalid columns are supplied, do we error out?
-	std::map<string, int unsigned> namesOfColumnsToOutput;
+	std::map<std::string, int unsigned> namesOfColumnsToOutput;
 	bool bExcludeSpecifiedColumns; //if set, namesOfColumnsToOutput is an exclusion set, and not an inclusion set
 	bool bOutputEmptyMissingColumns; //if set, output an empty column
 
 	//Header info.
 	int indexForVirtualBaseNameColumn;
 	int indexForVirtualRowColumn;
-	vector<string> columnNames;
+	std::vector<std::string> columnNames;
 	UCHAR *columnType;    //column value representation (e.g. string, numeric, char)
 	USHORT *columnCharSize; //char size of field (where applicable)
 	int *outputColumns; //flags to indicate which columns to output (non-negative values), and in what order
-	std::map<int, string> blankColumnNames;
+	std::map<int, std::string> blankColumnNames;
 
 	//Used when unpacking a block.
 	UCHAR *columnSize, *setColumns;
@@ -217,11 +213,11 @@ private:
 	void readVisitorDictionary();
 	void readColumnFieldStats();
 
-	ERR_CODE outputDesc(const vector<string>& columnNames, FILE* out);
-	vector<string> getDesc(const vector<string>& columnNames,
-		const string& name_type_separator, const string& delimiter) const;
-	string getColumnDesc(const string& name, UCHAR type, size_t index,
-		const string& name_type_separator, const string& delimiter) const;
+	ERR_CODE outputDesc(const std::vector<std::string>& columnNames, FILE* out);
+	std::vector<std::string> getDesc(const std::vector<std::string>& columnNames,
+		const std::string& name_type_separator, const std::string& delimiter) const;
+	std::string getColumnDesc(const std::string& name, UCHAR type, size_t index,
+		const std::string& name_type_separator, const std::string& delimiter) const;
 
 	size_t currentRowNumber;
 };
@@ -293,8 +289,8 @@ public:
 	// Call getNumOutputColumns or getRow first to retrieve the actual value of line length
 	ULONG getLineLength() {return this->exportFileLineLength + this->virtualLineLength;}
 
-	void getColumnNamesVector(vector<string> &columnNamesVector);
-	bool hasColumnName(const string& name) const;
+	void getColumnNamesVector(std::vector<std::string> &columnNamesVector);
+	bool hasColumnName(const std::string& name) const;
 
 	//output desc.sql file to {outputDir} directory
 	bool OutputDescToFile(const std::string &outputDir);

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -128,11 +128,10 @@ protected:
 	size_t skipBytes(const size_t len);
 	char* GetWord(ULONG index, char* row);
 
-	
 	static string GetBaseNameForInFile(const std::string &inFileName);
 	bool UseVirtualExportBaseNameColumn() const;
 	void EnableVirtualExportBaseNameColumn();
-	
+
 	bool UseVirtualExportRowColumn() const;
 	void EnableVirtualExportRowColumn();
 

--- a/cplusplus/convertDWfile.cpp
+++ b/cplusplus/convertDWfile.cpp
@@ -31,7 +31,7 @@ void showVersion()
 void usage(const char* executable)
 {
 	const char* exe = strrchr(executable, '/');
-	if(exe)
+	if (exe)
 		++exe; //skip '/'
 	else
 		exe = executable;
@@ -84,7 +84,7 @@ int badParam(const char* exeName, const char* paramStr)
 
 int main(int argc, char* argv[])
 {
-	const char *program = argv[0];
+	const char* program = argv[0];
 	if (argc < 2)
 	{
 		ShowHelp(program);
@@ -98,17 +98,17 @@ int main(int argc, char* argv[])
 	bool validate = false;
 	bool bQuiet = false;
 	ConvertToZDW::Compressor compressor = ConvertToZDW::GZIP;
-	const char *pOutputDir = NULL; //default = current dir
-	const char *zArgs = NULL;
+	const char* pOutputDir = NULL; //default = current dir
+	const char* zArgs = NULL;
 
 	//Parse flags.
 	int i;
 	int filenum = 0;
-	for(i = 1; i < argc; i++)
+	for (i = 1; i < argc; i++)
 	{
-		if(argv[i][0] == '-')
+		if (argv[i][0] == '-')
 		{
-			switch(argv[i][1])
+			switch (argv[i][1])
 			{
 				case 'b': compressor = ConvertToZDW::BZIP2; break;
 				case 'J': compressor = ConvertToZDW::XZ;    break;
@@ -127,7 +127,7 @@ int main(int argc, char* argv[])
 				case 'v': validate = true; break;
 				case '-': //i.e., '--[text]'
 					{
-						const char* flag = argv[i]+2;
+						const char* flag = argv[i] + 2;
 						if (!strcmp(flag, "help"))
 						{
 							ShowHelp(program);
@@ -138,12 +138,12 @@ int main(int argc, char* argv[])
 							return ConvertToZDW::OK;
 						}
 						if (!strncmp(flag, "mem-limit=", 10)) {
-							if (!Memory::set_memory_threshold_MB(atof(flag+10)))
+							if (!Memory::set_memory_threshold_MB(atof(flag + 10)))
 								return badParam(program, argv[i]);
 							break;
 						}
 						if (!strncmp(flag, "zargs=", 6)) {
-							zArgs = flag+6;
+							zArgs = flag + 6;
 							break;
 						}
 					}
@@ -166,7 +166,7 @@ int main(int argc, char* argv[])
 
 	//Parse files.
 	filenum = 0;
-	for(i = 1; i < argc; i++)
+	for (i = 1; i < argc; i++)
 	{
 		if (argv[i][0] == '-')
 		{
@@ -198,9 +198,9 @@ int main(int argc, char* argv[])
 				}
 				iRet = ConvertToZDW::CONVERSION_FAILED; //to preserve existing error code API?
 			}
-			if(removeOldFiles)
+			if (removeOldFiles)
 			{
-				if(res != ConvertToZDW::OK)
+				if (res != ConvertToZDW::OK)
 				{
 					fprintf(stderr, "Could not remove original %s file because conversion was not good\n", filestub);
 				}

--- a/cplusplus/dictionary.cpp
+++ b/cplusplus/dictionary.cpp
@@ -24,7 +24,7 @@ void Dictionary::clear()
 //Returns: true if additional memory is available, or false if memory limit has been exceeded
 bool Dictionary::insert(const char* str)
 {
-	std::pair<DictionaryT::iterator,bool> ret =
+	std::pair<DictionaryT::iterator, bool> ret =
 		stringOffsets.insert(std::pair<const char*, int unsigned>(str, 0));
 
 	if (ret.second) {
@@ -57,7 +57,7 @@ ULONG Dictionary::getBytesInOffset() const
 {
 	ULONG indexSize = 1;
 	ULONG maxIndex = getSize();
-	while(maxIndex >= 256)
+	while (maxIndex >= 256)
 	{
 		++indexSize;
 		maxIndex /= 256;
@@ -92,7 +92,7 @@ void Dictionary::write(FILE* f)
 	ULONG index = 1;
 
 	//Populate offsets and dump keys.
-	for (DictionaryT::iterator it=stringOffsets.begin(); it!=stringOffsets.end(); ++it)
+	for (DictionaryT::iterator it = stringOffsets.begin(); it != stringOffsets.end(); ++it)
 	{
 		it->second = index;
 		const char* str = it->first;

--- a/cplusplus/dictionary.h
+++ b/cplusplus/dictionary.h
@@ -20,16 +20,14 @@
 #include <map>
 #include <string>
 
-using std::map;
-using std::string;
 
 //********************************************************
 struct cstringComp {
 	bool operator() (const char* const& lhs, const char* const& rhs) const { return std::strcmp(lhs,rhs) < 0; }
 };
 
-typedef map<const char*, ULONG, cstringComp> DictionaryT;
-//typedef map<string, ULONG> DictionaryT; //replaced with custom memory management
+typedef std::map<const char*, ULONG, cstringComp> DictionaryT;
+//typedef std::map<std::string, ULONG> DictionaryT; //replaced with custom memory management
 
 //********************************************************
 class Dictionary

--- a/cplusplus/dictionary.h
+++ b/cplusplus/dictionary.h
@@ -23,7 +23,7 @@
 
 //********************************************************
 struct cstringComp {
-	bool operator() (const char* const& lhs, const char* const& rhs) const { return std::strcmp(lhs,rhs) < 0; }
+	bool operator() (const char* const& lhs, const char* const& rhs) const { return std::strcmp(lhs, rhs) < 0; }
 };
 
 typedef std::map<const char*, ULONG, cstringComp> DictionaryT;

--- a/cplusplus/getnextrow.cpp
+++ b/cplusplus/getnextrow.cpp
@@ -38,7 +38,7 @@ int Common::GetNextRow(
 			continue;
 		}
 
-		bool bEndlineFound = row[len-1] == '\n';
+		bool bEndlineFound = row[len - 1] == '\n';
 		//Count number of char escapes.
 		e = 2;
 		while (e <= len && row[len - e] == '\\')
@@ -46,14 +46,14 @@ int Common::GetNextRow(
 
 		//If it's odd, an escape char interrupted getting the line of text.
 		//So, append some more text until the full line has been compiled.
-		bool bEndOfLine = bEndlineFound && ((e % 2)==0);
+		bool bEndOfLine = bEndlineFound && ((e % 2) == 0);
 		while (str && !bEndOfLine)
 		{
 			//Ensure there is enough space to hold an entire row in the buffer.
-			const bool bBufferFull = (len == rowSize-1);
+			const bool bBufferFull = (len == rowSize - 1);
 			if (bBufferFull)
 			{
-				char *temp = new char[rowSize*2]; //strategy to avoid many reallocations
+				char *temp = new char[rowSize * 2]; //strategy to avoid many reallocations
 				strcpy(temp, row);
 				delete[] row;
 				row = temp;
@@ -65,12 +65,12 @@ int Common::GetNextRow(
 				return 0; //eof -- probably corrupted data
 			len += strlen(str);
 
-			bEndlineFound = row[len-1] == '\n';
+			bEndlineFound = row[len - 1] == '\n';
 			e = 2;
 			while (e <= len && row[len - e] == '\\')
 				++e;
 
-			bEndOfLine = bEndlineFound && ((e % 2)==0);
+			bEndOfLine = bEndlineFound && ((e % 2) == 0);
 		}
 		row[len - 1] = 0; //truncate trailing newline
 		break; //done reading this row

--- a/cplusplus/memory.cpp
+++ b/cplusplus/memory.cpp
@@ -23,29 +23,29 @@ float Memory::memory_threshold_mb = DEFAULT_PROCESS_MEMORY_THRESHOLD;
 //Returns: allocated memory, in MB
 double Memory::process_memory_usage()
 {
-    double vm_usage = 0.0;
+	double vm_usage = 0.0;
 
-    string pid, comm, state, ppid, pgrp, session, tty_nr, tpgid, flags;
-    string minflt, cminflt, majflt, cmajflt, utime, stime, cutime, cstime;
-    string priority, nice, O, itrealvalue, starttime;
+	string pid, comm, state, ppid, pgrp, session, tty_nr, tpgid, flags;
+	string minflt, cminflt, majflt, cmajflt, utime, stime, cutime, cstime;
+	string priority, nice, O, itrealvalue, starttime;
 
-    unsigned long long vsize;
+	unsigned long long vsize;
 
-    std::ifstream stat_stream("/proc/self/stat");
+	std::ifstream stat_stream("/proc/self/stat");
 
-    if(stat_stream.good())
-    {
-        stat_stream >> pid >> comm >> state >> ppid >> pgrp >> session >>tty_nr
-            >> tpgid >> flags >> minflt >> cminflt >> majflt >> cmajflt
-            >> utime >> stime >> cutime >> cstime >> priority >> nice
-            >> O >> itrealvalue >> starttime >> vsize;
+	if (stat_stream.good())
+	{
+		stat_stream >> pid >> comm >> state >> ppid >> pgrp >> session >>tty_nr
+			>> tpgid >> flags >> minflt >> cminflt >> majflt >> cmajflt
+			>> utime >> stime >> cutime >> cstime >> priority >> nice
+			>> O >> itrealvalue >> starttime >> vsize;
 
-        stat_stream.close();
+		stat_stream.close();
 
-        vm_usage = vsize / (1024.0 * 1024.0); //bytes --> MB
-    }
+		vm_usage = vsize / (1024.0 * 1024.0); //bytes --> MB
+	}
 
-    return vm_usage;
+	return vm_usage;
 }
 
 float Memory::get_memory_usage_limit_MB()

--- a/cplusplus/stringheap.cpp
+++ b/cplusplus/stringheap.cpp
@@ -17,7 +17,7 @@
 #include <cstring>
 #include <stdio.h>
 
-const size_t HEAP_BLOCK_SIZE = 64*1024*1024;
+const size_t HEAP_BLOCK_SIZE = 64 * 1024 * 1024;
 
 char* StringHeap::copyToHeap(const char* str, const size_t len)
 {

--- a/cplusplus/stringheap.h
+++ b/cplusplus/stringheap.h
@@ -16,7 +16,6 @@
 #include <list>
 #include <cstring>
 
-using std::size_t;
 
 class StringHeap
 {

--- a/cplusplus/test_unconvert_api.cpp
+++ b/cplusplus/test_unconvert_api.cpp
@@ -23,7 +23,7 @@
 void ShowHelp(char* executable)
 {
 	char* exe = strrchr(executable, '/');
-	if(exe)
+	if (exe)
 		++exe; //skip '/'
 	else
 		exe = executable;
@@ -38,9 +38,9 @@ void ShowHelp(char* executable)
 void processLine(const char** outColumns, size_t numColumns)
 {
 	assert(outColumns);
-	for (size_t col=0; col<numColumns; ++col) {
+	for (size_t col = 0; col < numColumns; ++col) {
 		printf("%s", outColumns[col]);
-		if (col<numColumns-1)
+		if (col<numColumns - 1)
 			printf("\t");
 	}
 	printf("\n");
@@ -57,7 +57,7 @@ int main(int argc, char* argv[]) {
 	string namesOfColumnsToOutput;
 	if (!strcmp(argv[1], "-ci"))
 	{
-		if(argc < 4)
+		if (argc < 4)
 		{
 			ShowHelp(argv[0]);
 			exit(1);
@@ -68,10 +68,10 @@ int main(int argc, char* argv[]) {
 	}
 
 	//Each iteration unconverts one ZDW input file.
-	for (int i=fileBeginIndex; i<argc; ++i)
+	for (int i = fileBeginIndex; i < argc; ++i)
 	{
 		UnconvertFromZDWToMemory unconvert(argv[i], false); //test in-memory API
-		if(!namesOfColumnsToOutput.empty())
+		if (!namesOfColumnsToOutput.empty())
 		{
 			unconvert.setNamesOfColumnsToOutput(namesOfColumnsToOutput, ZDW::SKIP_INVALID_COLUMN);
 		}

--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -20,6 +20,9 @@
 #include <stdlib.h>
 #include <algorithm>
 
+using std::string;
+
+
 //*****************************
 void showVersion()
 {

--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -34,7 +34,7 @@ void showVersion()
 void usage(char* executable)
 {
 	char* exe = strrchr(executable, '/');
-	if(exe)
+	if (exe)
 		++exe; //skip '/'
 	else
 		exe = executable;
@@ -213,7 +213,7 @@ int main(int argc, char* argv[])
 				case 'a':
 				case 'c':
 				case 'd':
-					if (argc <= i+1)
+					if (argc <= i + 1)
 						return missingParam(argv[0], argv[i]);
 				break;
 			}
@@ -242,7 +242,7 @@ int main(int argc, char* argv[])
 					specifiedDir = argv[++i];
 					//Cut off any trailing /
 					c = specifiedDir.size() - 1;
-					if(specifiedDir[c] == '/')
+					if (specifiedDir[c] == '/')
 						specifiedDir.resize(c);
 					break;
 				case 'i': //read from stdin and output to stdout
@@ -268,7 +268,7 @@ int main(int argc, char* argv[])
 					break;
 				case '-': //i.e., '--[text]'
 					{
-						const char* flag = argv[i]+2;
+						const char* flag = argv[i] + 2;
 						if (strlen(flag) == 0) //"--" for outputting to stdout is deprecated
 							bStdout = true;
 						else if (!strcmp(flag, "help"))
@@ -305,7 +305,7 @@ int main(int argc, char* argv[])
 				break;
 			}
 		} else {
-			if(argv[i][0] == '\0') {
+			if (argv[i][0] == '\0') {
 				return emptyFilename(argv[0]);
 			}
 			if (bStdin) {


### PR DESCRIPTION

## Description

In order to build on CentOS-6.2, I was forced to revert the cmake-2.8 change.
I then spent a little time removing C-style casts from the code (and enabling -Wold-style-cast), and cleaning up some whitespace stuff so that the style is much more consistent.  (Though I'm sure I still missed some stuff.)

## Motivation and Context

CentOS-6.2 doesn't provide cmake-2.8, only 2.6.

## How Has This Been Tested?

Tested on Adobe CentOS-6.2 image with provided movie_tickets file.  (Uncompressed and compared to provided raw files, then re-compressed with -v option.)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Whitespace changes

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

