### PR TITLE
Add status output callback facility to log to something other than stdout/stderr

### DIFF
--- a/cplusplus/BufferedInput.h
+++ b/cplusplus/BufferedInput.h
@@ -85,7 +85,8 @@ public:
 	}
 
 	//Returns: whether any more data can be returned
-	bool eof() const {
+	bool eof() const
+	{
 		if (this->bFromStdin) {
 			return feof(stdin) != 0;
 		} else {
@@ -102,13 +103,14 @@ public:
 
 	void reset() { index = length = 0; }
 
-	bool can_read_more_data() const {
+	bool can_read_more_data() const
+	{
 		if (eof())
 			return false;
 		if (is_gz_file) {
 			if (!this->gzFp)
 				return false;
-		} else if (!this->fp){
+		} else if (!this->fp) {
 			return false;
 		}
 		return true;
@@ -231,7 +233,8 @@ public:
 
 	//Skip ahead the indicated number of bytes without outputting any of the data.
 	//Returns: number of bytes skipped
-	size_t skip(size_t size) {
+	size_t skip(size_t size)
+	{
 		//Read blocks for speed.
 		static const size_t BLOCK_SIZE = 16;
 		char tempBlock[BLOCK_SIZE];
@@ -258,7 +261,7 @@ public:
 		if (is_gz_file) {
 			if (!this->gzFp)
 				return 0;
-		} else if (!this->fp){
+		} else if (!this->fp) {
 			return 0;
 		}
 

--- a/cplusplus/BufferedOutput.h
+++ b/cplusplus/BufferedOutput.h
@@ -28,7 +28,8 @@ private:
 	BufferedOrderedOutput &operator=(BufferedOrderedOutput const &);
 
 	//Used for reordering column outputs.
-	class ByteBuffer {
+	class ByteBuffer
+	{
 	public:
 		ByteBuffer(int unsigned startSize = 16)
 		: pBuffer(new char[startSize])
@@ -263,7 +264,6 @@ extern int compareByOutputIndex(const void* first, const void* second);
 class BufferedOutputInMem
 {
 public:
-
 	BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer = true)
 		: ppBuffer(NULL)
 		, pBuffer(NULL)
@@ -411,7 +411,7 @@ private:
 	{
 		assert(pBufferSize);
 		assert(ppBuffer);
-		if (requiredSize > *pBufferSize){
+		if (requiredSize > *pBufferSize) {
 			delete [] pBuffer;
 			pBuffer = new char [requiredSize];
 			*ppBuffer = pBuffer;

--- a/cplusplus/BufferedOutput.h
+++ b/cplusplus/BufferedOutput.h
@@ -273,6 +273,7 @@ public:
 		, pColumnsBuffer(NULL)
 		, pOutputOrder(NULL)
 		, numColumns(0)
+		, currentRowLength(0)
 		, neededBufferSize(neededBufferSize)
 		, bUseInternalBuffer(bUseInternalBuffer)
 		, bNeedReorder(false)

--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -18,6 +18,8 @@ add_library(zdw
 	getnextrow.h
 	stringheap.cpp
 	stringheap.h
+	status_output.cpp
+	status_output.h
 	includes.h
 	zdw_column_type_constants.h
 )

--- a/cplusplus/ConvertToZDW.cpp
+++ b/cplusplus/ConvertToZDW.cpp
@@ -353,9 +353,7 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 								columnMax[c] = val;
 							else if (val < columnMin[c])
 								columnMin[c] = val;
-						}
-						else
-						{
+						} else {
 							columnMax[c] = columnMin[c] = val;
 							minmaxset[c] = 1;
 						}
@@ -379,9 +377,7 @@ ConvertToZDW::INPUT_STATUS ConvertToZDW::parseInput(FILE* in)
 								columnMax[c] = val;
 							else if (val < columnMin[c])
 								columnMin[c] = val;
-						}
-						else
-						{
+						} else {
 							columnMax[c] = columnMin[c] = val;
 							minmaxset[c] = 1;
 						}
@@ -874,9 +870,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		{
 			if (!this->bQuiet)
 				printf("%s GOOD\n", zdwFile);
-		}
-		else
-		{
+		} else {
 			printf("%s BAD\n", zdwFile);
 			res = eValid;
 		}

--- a/cplusplus/ConvertToZDW.h
+++ b/cplusplus/ConvertToZDW.h
@@ -164,4 +164,3 @@ private:
 };
 
 #endif
-

--- a/cplusplus/ConvertToZDW.h
+++ b/cplusplus/ConvertToZDW.h
@@ -14,6 +14,7 @@
 #define CONVERTTOZDW_H
 
 #include "dictionary.h"
+#include "status_output.h"
 
 #include <string>
 #include <vector>
@@ -67,6 +68,7 @@ public:
 		, m_row(NULL)
 		, m_Version(CONVERT_ZDW_CURRENT_VERSION)
 		, minmaxset(NULL), columnSize(NULL)
+		, statusOutput(ZDW::defaultStatusOutputCallback)
 		, bQuiet(bQuiet)
 		, bTrimTrailingSpaces(false)
 		, bStreamingInput(bStreamingInput)
@@ -78,6 +80,8 @@ public:
 		delete[] minmaxset;
 		delete[] columnSize;
 	}
+
+	void setStatusOutputCallback(ZDW::StatusOutputCallback cb) { statusOutput = cb; }
 
 	void trimTrailingSpaces(bool val = true) { bTrimTrailingSpaces = val; }
 	const char* getInputFileExtension() const { return "sql"; }
@@ -155,6 +159,8 @@ private:
 	std::vector<ULONGLONG> columnVal;
 	std::vector<storageBytes> columnStoredVal[2];
 	std::vector<short> usedColumn;
+
+	ZDW::StatusOutputCallback statusOutput;
 
 	const bool bQuiet; //quiet running (no progress output messages)
 	bool bTrimTrailingSpaces;

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -180,6 +180,7 @@ UnconvertFromZDW_Base::UnconvertFromZDW_Base(const string &fileName,
 	, bShowBasicStatisticsOnly(false)
 	, bFailOnInvalidColumns(true)
 	, bExcludeSpecifiedColumns(false)
+	, bOutputEmptyMissingColumns(false)
 	, indexForVirtualBaseNameColumn(IGNORE)
 	, indexForVirtualRowColumn(IGNORE)
 	, columnType(NULL)

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -152,7 +152,7 @@ struct InsensitiveCompare
 //API maintenance -- old breakdown currently uses this text to detect whether zdw unconvert failed or not
 void UnconvertFromZDW_Base::printError(const string &exeName, const string &fileName)
 {
-	fprintf(stderr, "%s: %s failed\n\n", !exeName.empty() ? exeName.c_str() : "UnconvertFromZDW", fileName.c_str());
+	statusOutput(ERROR, "%s: %s failed\n\n", !exeName.empty() ? exeName.c_str() : "UnconvertFromZDW", fileName.c_str());
 }
 
 //***********************************************
@@ -479,7 +479,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::outputDescToFile(
 	sprintf(outFileName, "%s/%s.desc%s", outputDir, filestub, ext ? ext : "");
 	FILE *out = fopen(outFileName, "w");
 	if (!out) {
-		fprintf(stderr, "%s: Could not open %s for writing\n", exeName.c_str(), outFileName);
+		statusOutput(ERROR, "%s: Could not open %s for writing\n", exeName.c_str(), outFileName);
 		return FILE_CREATION_ERR;
 	}
 
@@ -494,7 +494,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::outputDescToStdOut(
 	FILE *out = stdout;
 	if (!out)
 	{
-		fprintf(stderr, "%s: Could not open STDOUT for writing\n", exeName.c_str());
+		statusOutput(ERROR, "%s: Could not open STDOUT for writing\n", exeName.c_str());
 		return FILE_CREATION_ERR;
 	}
 
@@ -708,7 +708,7 @@ void UnconvertFromZDW_Base::readLineLength()
 		}
 	}
 	if (this->bShowBasicStatisticsOnly) {
-		fprintf(this->statusOutput, "Max line length = %lu\n", static_cast<long unsigned>(this->exportFileLineLength));
+		this->statusOutput(INFO, "Max line length = %lu\n", static_cast<long unsigned>(this->exportFileLineLength));
 	}
 }
 
@@ -730,7 +730,7 @@ void UnconvertFromZDW_Base::readDictionary()
 	//Read dictionary.
 	if (this->version >= 9) {
 		if (!this->bQuiet)
-			fprintf(this->statusOutput, "Reading %" PF_LLU " byte dictionary\n", this->dictionarySize);
+			this->statusOutput(INFO, "Reading %" PF_LLU " byte dictionary\n", this->dictionarySize);
 		if (this->bShowBasicStatisticsOnly) {
 			skipBytes(this->dictionarySize);
 		} else {
@@ -753,7 +753,7 @@ void UnconvertFromZDW_Base::readDictionary()
 			memset(this->uniques, 0, (this->dictionarySize + 1) * sizeof(UniquesPart));
 		}
 		if (!this->bQuiet)
-			fprintf(this->statusOutput, "Reading %" PF_LLU " uniques\n", this->dictionarySize);
+			this->statusOutput(INFO, "Reading %" PF_LLU " uniques\n", this->dictionarySize);
 
 		if (this->bShowBasicStatisticsOnly) {
 			//Just skip through this data.
@@ -769,12 +769,11 @@ void UnconvertFromZDW_Base::readDictionary()
 				readBytes(this->uniques[c].m_PrevChar.c, indexSize);
 				if (this->bShowStatus && !(c % OUTPUT_MOD))
 				{
-					fprintf(this->statusOutput, "\r%u", c - 1);
-					fflush(this->statusOutput);
+					this->statusOutput(INFO, "\r%u", c - 1);
 				}
 			}
 			if (this->bShowStatus && indexSize != 0)
-				fprintf(this->statusOutput, "\r%u\n", c - 1);
+				this->statusOutput(INFO, "\r%u\n", c - 1);
 		}
 	}
 
@@ -836,7 +835,7 @@ void UnconvertFromZDW_Base::readVisitorDictionary()
 		this->visitors = new VisitorPart[this->numVisitors + 1];
 		memset(this->visitors, 0, (this->numVisitors + 1) * sizeof(VisitorPart));
 		if (!this->bQuiet)
-			fprintf(this->statusOutput, "Reading %" PF_LLU " visitor indices\n", this->numVisitors);
+			this->statusOutput(INFO, "Reading %" PF_LLU " visitor indices\n", this->numVisitors);
 
 		//Read visitor IDs
 		if (this->bShowBasicStatisticsOnly) {
@@ -853,12 +852,11 @@ void UnconvertFromZDW_Base::readVisitorDictionary()
 				readBytes(this->visitors[c].m_PrevID.c, vIndexSize);
 				if (this->bShowStatus && !(c % OUTPUT_MOD))
 				{
-					fprintf(this->statusOutput, "\r%u", c - 1);
-					fflush(this->statusOutput);
+					this->statusOutput(INFO, "\r%u", c - 1);
 				}
 			}
 			if (this->bShowStatus && vIndexSize != 0)
-				fprintf(this->statusOutput, "\r%u\n", c - 1);
+				this->statusOutput(INFO, "\r%u\n", c - 1);
 		}
 	}
 }
@@ -935,7 +933,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 		}
 	}
 	if (this->bShowBasicStatisticsOnly)
-		fprintf(this->statusOutput, "File version %d\n", static_cast<int>(this->version));
+		this->statusOutput(INFO, "File version %d\n", static_cast<int>(this->version));
 
 	//3. Parse column names.
 	this->columnNames.clear();
@@ -1318,7 +1316,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 
 	//5. Start parsing rows.
 	if (!this->bQuiet)
-		fprintf(this->statusOutput, "Reading %u rows\n", this->numLines);
+		this->statusOutput(INFO, "Reading %u rows\n", this->numLines);
 
 	//Show compression statistics when both test and statistics modes are set.
 	ULONGLONG equalityBitsSet = 0;
@@ -1424,14 +1422,13 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 			//Progress.
 			if (this->bShowStatus && !(this->rowsRead % 10000))
 			{
-				fprintf(this->statusOutput, "\r%u", this->rowsRead);
-				fflush(this->statusOutput);
+				this->statusOutput(INFO, "\r%u", this->rowsRead);
 			}
 		}
 
 		//Final progress for this block.
 		if (this->bShowStatus)
-			fprintf(this->statusOutput, "\r%u\n", this->rowsRead);
+			this->statusOutput(INFO, "\r%u\n", this->rowsRead);
 	}
 
 	//Finished unconverting this block.
@@ -1440,7 +1437,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 		(!this->bShowBasicStatisticsOnly || !isLastBlock()))
 	{
 		printError(this->exeName, getInputFilename(this->inFileName));
-		fprintf(this->statusOutput, "Rows unpacked (%u) does not match expected (%u)\n\n",
+		this->statusOutput(INFO, "Rows unpacked (%u) does not match expected (%u)\n\n",
 			this->rowsRead, this->numLines);
 		return ROW_COUNT_ERR;
 	}
@@ -1453,20 +1450,20 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::parseNextBlock(T& buffer)
 				++nonEmptyColumns;
 		}
 
-		fprintf(this->statusOutput, "Equality delta bits set: %" PF_LLU " (%0.1f%%) (rows=%u, columns=%u, bit vector width=%ld bytes, non-empty columns=%zu (%0.1f%%)\n",
+		this->statusOutput(INFO, "Equality delta bits set: %" PF_LLU " (%0.1f%%) (rows=%u, columns=%u, bit vector width=%ld bytes, non-empty columns=%zu (%0.1f%%)\n",
 			equalityBitsSet, equalityBitsSet*100 / float(this->numLines * this->numSetColumns * 8),
 			this->numLines, this->numColumnsInExportFile, this->numSetColumns,
 			nonEmptyColumns, nonEmptyColumns*100/float(this->numColumnsInExportFile));
 
 		for (size_t c = 0; c < nonEmptyColumns; ++c) {
-			fprintf(this->statusOutput, "%u ", equalityBitsInColumn[c]);
+			this->statusOutput(INFO, "%u ", equalityBitsInColumn[c]);
 		}
-		fprintf(this->statusOutput, "\n");
+		this->statusOutput(INFO, "\n");
 	}
 
 	if (isLastBlock() && !this->bQuiet && !this->bShowBasicStatisticsOnly)
 	{
-		fprintf(this->statusOutput, "%s %s\n\n",
+		this->statusOutput(INFO, "%s %s\n\n",
 				getInputFilename(this->inFileName).c_str(), this->bTestOnly ? "tested good" : "uncompressed");
 	}
 
@@ -1498,7 +1495,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 	}
 
 	if (!this->isReadOpen()) {
-		fprintf(stderr, "%s: Could not open %s for reading\n", this->exeName.c_str(), getInputFilename(this->inFileName).c_str());
+		this->statusOutput(ERROR, "%s: Could not open %s for reading\n", this->exeName.c_str(), getInputFilename(this->inFileName).c_str());
 		return FILE_OPEN_ERR;
 	}
 
@@ -1524,8 +1521,10 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 	if (!outputBasename)
 		outputBasename = filestub;
 
-	//When outputting status messages, where do they get outputted?
-	this->statusOutput = bStdout ? stderr : stdout;
+	if (!this->statusOutput) {
+		//When outputting status messages, where do they get outputted?
+		this->statusOutput = bStdout ? stdErrStatusOutputCallback : defaultStatusOutputCallback;
+	}
 
 	if (this->bShowStatus) {
 		const char *status;
@@ -1537,7 +1536,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 			status = "Outputting .desc file only";
 		else
 			status = "Processing";
-		fprintf(this->statusOutput, "\n%s %s\n", filestub, status);
+		this->statusOutput(INFO, "\n%s %s\n", filestub, status);
 	}
 
 	//1. Read header info.
@@ -1545,7 +1544,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 	if (eRet != OK)
 	{
 		if (eRet == UNSUPPORTED_ZDW_VERSION_ERR)
-			fprintf(stderr, "%s: %s is newer (version %d) than supported version (%d)\n%s\n", this->exeName.c_str(), filestub, this->version, UnconvertFromZDW_Base::UNCONVERT_ZDW_VERSION, this->version > 10000 ? "Maybe you are trying to read a tar or gzip file?\n" : "");
+			this->statusOutput(ERROR, "%s: %s is newer (version %d) than supported version (%d)\n%s\n", this->exeName.c_str(), filestub, this->version, UnconvertFromZDW_Base::UNCONVERT_ZDW_VERSION, this->version > 10000 ? "Maybe you are trying to read a tar or gzip file?\n" : "");
 		goto Done;
 	}
 
@@ -1555,7 +1554,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 		char textbuf[1024];
 		sprintf(textbuf, "%s/%s%s", outputDir, outputBasename, ext ? ext : "");
 		if (this->bShowStatus)
-			fprintf(this->statusOutput, "Writing %s\n", textbuf);
+			this->statusOutput(INFO, "Writing %s\n", textbuf);
 		//Open output stream.
 		if (bStdout) {
 			this->out = stdout;
@@ -1564,7 +1563,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 		}
 		if (!this->out)
 		{
-			fprintf(stderr, "%s: Could not open %s for writing\n", this->exeName.c_str(), textbuf);
+			this->statusOutput(ERROR, "%s: Could not open %s for writing\n", this->exeName.c_str(), textbuf);
 			eRet = FILE_CREATION_ERR;
 			goto Done;
 		}
@@ -1578,7 +1577,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 		eDescErr = bStdout ? this->outputDescToStdOut(this->columnNames) : this->outputDescToFile(this->columnNames, outputDir, outputBasename, ext);
 		if (eDescErr != OK)
 		{
-			fprintf(stderr, "%s: Could not extract the %s.desc%s file\n", this->exeName.c_str(), outputBasename, ext ? ext : "");
+			this->statusOutput(ERROR, "%s: Could not extract the %s.desc%s file\n", this->exeName.c_str(), outputBasename, ext ? ext : "");
 			eRet = eDescErr;
 			goto Done;
 		}
@@ -1627,7 +1626,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToFile<BufferedOutput_T>::unconv
 		this->readBytes(&dummy, 1, false); //a dummy read to set eof if we're at the end
 		if (!this->isFinished())
 		{
-			fprintf(this->statusOutput, "Did not reach EOF\n");
+			this->statusOutput(INFO, "Did not reach EOF\n");
 			eRet = ZDW_LONGER_THAN_EXPECTED_ERR;
 		}
 	}

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -65,9 +65,20 @@ const char UnconvertFromZDW_Base::UNCONVERT_ZDW_VERSION_TAIL[3] = "";
 const size_t UnconvertFromZDW_Base::DEFAULT_LINE_LENGTH = 16*1024; //16K default
 
 const char UnconvertFromZDW_Base::ERR_CODE_TEXTS[ZDW::ERR_CODE_COUNT + 1][30] = {
-	"OK","BAD_PARAMETER","GZREAD_FAILED","FILE_CREATION_ERR","FILE_OPEN_ERR","UNSUPPORTED_ZDW_VERSION_ERR",
-	"ZDW_LONGER_THAN_EXPECTED_ERR","UNEXPECTED_DESC_TYPE","ROW_COUNT_ERR","CORRUPTED_DATA_ERROR",
-	"HEADER_NOT_READ_YET","HEADER_ALREADY_READ_ERR","AT_END_OF_FILE","BAD_REQUESTED_COLUMN",
+	"OK",
+	"BAD_PARAMETER",
+	"GZREAD_FAILED",
+	"FILE_CREATION_ERR",
+	"FILE_OPEN_ERR",
+	"UNSUPPORTED_ZDW_VERSION_ERR",
+	"ZDW_LONGER_THAN_EXPECTED_ERR",
+	"UNEXPECTED_DESC_TYPE",
+	"ROW_COUNT_ERR",
+	"CORRUPTED_DATA_ERROR",
+	"HEADER_NOT_READ_YET",
+	"HEADER_ALREADY_READ_ERR",
+	"AT_END_OF_FILE",
+	"BAD_REQUESTED_COLUMN",
 	"NO_COLUMNS_TO_OUTPUT",
 	"PROCESSING_ERROR",
 	"UNSUPPORTED_OPERATION",
@@ -81,7 +92,8 @@ char const * const VIRTUAL_EXPORT_BASENAME_COLUMN_NAME = "virtual_export_basenam
 char const * const VIRTUAL_EXPORT_ROW_COLUMN_NAME = "virtual_export_row";
 
 namespace {
-	string getInputFilename(string filename) {
+	string getInputFilename(string filename)
+	{
 		return !filename.empty() ? filename : string("stdin");
 	}
 
@@ -128,8 +140,10 @@ namespace {
 }
 
 //*****************************
-struct InsensitiveCompare {
-	bool operator() (const string& lhs, const string& rhs) const {
+struct InsensitiveCompare
+{
+	bool operator() (const string& lhs, const string& rhs) const
+	{
 		return strcasecmp(lhs.c_str(), rhs.c_str()) < 0;
 	}
 };
@@ -391,8 +405,7 @@ bool UnconvertFromZDW_Base::setNamesOfColumnsToOutput(
 			++index;
 			if (column_name == VIRTUAL_EXPORT_BASENAME_COLUMN_NAME && !this->bExcludeSpecifiedColumns) {
 				EnableVirtualExportBaseNameColumn();
-			}
-			else if (column_name == VIRTUAL_EXPORT_ROW_COLUMN_NAME && !this->bExcludeSpecifiedColumns) {
+			} else if (column_name == VIRTUAL_EXPORT_ROW_COLUMN_NAME && !this->bExcludeSpecifiedColumns) {
 				EnableVirtualExportRowColumn();
 			}
 		} else {
@@ -525,8 +538,8 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::GetSchema(
 	return OK;
 }
 
-string UnconvertFromZDW_Base::GetBaseNameForInFile(const string &inFileName) {
-
+string UnconvertFromZDW_Base::GetBaseNameForInFile(const string &inFileName)
+{
 	if (inFileName.empty()) {
 		//return "No Input Filename Found";
 		return string();
@@ -931,8 +944,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 		size_t p = 0;
 		do {
 			readBytes(&(row[++p]), 1);
-		}
-		while (row[p]);
+		} while (row[p]);
 		this->columnNames.push_back(row);
 		readBytes(row, 1); //pass null terminator
 	}
@@ -1052,7 +1064,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW_Base::readHeader()
 	if (UseVirtualExportRowColumn()) {
 		this->columnType[this->indexForVirtualRowColumn] = VIRTUAL_EXPORT_ROW;
 		if (this->columnCharSize) {
-		  this->columnCharSize[this->indexForVirtualRowColumn] = 0;
+			this->columnCharSize[this->indexForVirtualRowColumn] = 0;
 		}
 	}
 
@@ -1174,9 +1186,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDW<T>::readNextRow(T& buffer)
 			//if (this->columnType[c] == VISID_HIGH) visid_low = 0;
 			//in order to write out a default value for visid_low, this logic should technically happen here, and in the "if (this->outputColumns[c] == IGNORE)" block above.
 			//However, since visid_low already defaults to 0 above, we don't actually need to execute this check and assignment and slow things down.
-		}
-		else
-		{
+		} else {
 			//3. Read new value of this column when it is not the same as that of the previous row.
 			storageBytes& val = this->columnVal[c];
 			if (this->setColumns[u / 8] & (1u << (u % 8))) //is the bit for this column set?
@@ -1633,19 +1643,23 @@ Done:
 	return eRet;
 }
 
-bool UnconvertFromZDW_Base::UseVirtualExportBaseNameColumn() const {
+bool UnconvertFromZDW_Base::UseVirtualExportBaseNameColumn() const
+{
 	return indexForVirtualBaseNameColumn != IGNORE;
 }
 
-void UnconvertFromZDW_Base::EnableVirtualExportBaseNameColumn() {
+void UnconvertFromZDW_Base::EnableVirtualExportBaseNameColumn()
+{
 	indexForVirtualBaseNameColumn = USE_VIRTUAL_COLUMN;
 }
 
-bool UnconvertFromZDW_Base::UseVirtualExportRowColumn() const {
+bool UnconvertFromZDW_Base::UseVirtualExportRowColumn() const
+{
 	return indexForVirtualRowColumn != IGNORE;
 }
 
-void UnconvertFromZDW_Base::EnableVirtualExportRowColumn() {
+void UnconvertFromZDW_Base::EnableVirtualExportRowColumn()
+{
 	indexForVirtualRowColumn = USE_VIRTUAL_COLUMN;
 }
 
@@ -1665,7 +1679,7 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(const char** ou
 	return getRow(NULL, NULL, outColumns, num);
 }
 
-UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(char ** buffer, size_t *size, const char** outColumns, size_t &numColumns)
+UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(char** buffer, size_t *size, const char** outColumns, size_t &numColumns)
 {
 	for (;;) {
 		switch (this->eState)
@@ -1723,9 +1737,9 @@ UnconvertFromZDW_Base::ERR_CODE UnconvertFromZDWToMemory::getRow(char ** buffer,
 				readBytes(&dummy, 1, false); //a dummy read to set eof if we're at the end
 
 				setState(ZDW_END);
-			return isFinished() ? AT_END_OF_FILE : ZDW_LONGER_THAN_EXPECTED_ERR;
+				return isFinished() ? AT_END_OF_FILE : ZDW_LONGER_THAN_EXPECTED_ERR;
 			case ZDW_END:
-			return AT_END_OF_FILE;
+				return AT_END_OF_FILE;
 		}
 	}
 }

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -305,4 +305,3 @@ private:
 };
 
 #endif
-

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -275,8 +275,7 @@ public:
 		, bUseInternalBuffer(bUseInternalBuffer)
 	{ }
 	~UnconvertFromZDWToMemory()
-	{
-	}
+	{ }
 
 	UnconvertFromZDW_Base::ERR_CODE getRow(const char** outColumns);
 

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -106,7 +106,7 @@ public:
 	bool isFinished() const { return this->input->eof(); }
 	bool isReadOpen() const { return this->input && this->input->is_open(); }
 
-	static void printError(const std::string &exeName, const std::string &inFileName);
+	void printError(const std::string &exeName, const std::string &inFileName);
 
 	ERR_CODE readHeader();
 	bool setNamesOfColumnsToOutput(const std::string& csv_str, ZDW::COLUMN_INCLUSION_RULE inclusionRule);

--- a/cplusplus/UnconvertFromZDW.h
+++ b/cplusplus/UnconvertFromZDW.h
@@ -17,6 +17,7 @@
 
 #include "BufferedInput.h"
 #include "BufferedOutput.h"
+#include "status_output.h"
 
 #include <map>
 #include <string>
@@ -96,6 +97,8 @@ public:
 			const bool bShowStatus = true, const bool bQuiet = true,
 			const bool bTestOnly = false, const bool bOutputDescFileOnly = false);
 	virtual ~UnconvertFromZDW_Base();
+
+	void setStatusOutputCallback(ZDW::StatusOutputCallback cb) { statusOutput = cb; }
 
 	//Common API.
 	std::vector<std::string> getColumnNames() const { return this->columnNames; }
@@ -189,7 +192,7 @@ protected:
 	ULONG rowsRead;
 	long numSetColumns;
 
-	FILE *statusOutput;
+	ZDW::StatusOutputCallback statusOutput;
 
 	//State info to assist API simplicity.
 	enum STATE
@@ -273,7 +276,9 @@ public:
 		: UnconvertFromZDW<BufferedOutputInMem>(inFileName, bShowStatus, bQuiet, bTestOnly, bOutputDescFileOnly)
 		, num_output_columns(0)
 		, bUseInternalBuffer(bUseInternalBuffer)
-	{ }
+	{
+		statusOutput = ZDW::defaultStatusOutputCallback;
+	}
 	~UnconvertFromZDWToMemory()
 	{ }
 

--- a/cplusplus/convertDWfile.cpp
+++ b/cplusplus/convertDWfile.cpp
@@ -203,9 +203,7 @@ int main(int argc, char* argv[])
 				if (res != ConvertToZDW::OK)
 				{
 					fprintf(stderr, "Could not remove original %s file because conversion was not good\n", filestub);
-				}
-				else
-				{
+				} else {
 					//Delete files converted from.
 					sprintf(filename, "%s.desc.%s", filestub, convert.getInputFileExtension());
 					unlink(filename);

--- a/cplusplus/dictionary.h
+++ b/cplusplus/dictionary.h
@@ -54,4 +54,3 @@ private:
 };
 
 #endif
-

--- a/cplusplus/dictionary.h
+++ b/cplusplus/dictionary.h
@@ -22,7 +22,8 @@
 
 
 //********************************************************
-struct cstringComp {
+struct cstringComp
+{
 	bool operator() (const char* const& lhs, const char* const& rhs) const { return std::strcmp(lhs, rhs) < 0; }
 };
 

--- a/cplusplus/getnextrow.h
+++ b/cplusplus/getnextrow.h
@@ -20,4 +20,3 @@ namespace Common {
 };
 
 #endif
-

--- a/cplusplus/includes.h
+++ b/cplusplus/includes.h
@@ -60,4 +60,3 @@ union storageBytes
 #define DECIMAL_FACTOR (1000000000000.0)      //version 2-3
 
 #endif //INCLUDES_H
-

--- a/cplusplus/status_output.cpp
+++ b/cplusplus/status_output.cpp
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+#include "status_output.h"
+#include <stdarg.h>
+#include <stdio.h>
+
+
+namespace ZDW {
+
+// ERROR to stderr, INFO to stdout
+void defaultStatusOutputCallback(const StatusOutputLevel level, const char *format, ...)
+{
+	FILE *outptr = (level == ERROR) ? stderr : stdout;
+
+	va_list argptr;
+	va_start(argptr, format);
+	vfprintf(outptr, format, argptr);
+	fflush(outptr);
+	va_end(argptr);
+}
+
+// Always output to stderr
+void stdErrStatusOutputCallback(const StatusOutputLevel level, const char *format, ...)
+{
+	va_list argptr;
+	va_start(argptr, format);
+	vfprintf(stderr, format, argptr);
+	fflush(stderr);
+	va_end(argptr);
+}
+
+}
+

--- a/cplusplus/status_output.h
+++ b/cplusplus/status_output.h
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+#ifndef ZDW_STATUS_OUTPUT_H
+#define ZDW_STATUS_OUTPUT_H
+
+
+namespace ZDW {
+
+enum StatusOutputLevel
+{
+	INFO,
+	ERROR,
+};
+
+typedef void (*StatusOutputCallback)(const StatusOutputLevel, const char *, ...);
+
+
+// ERROR to stderr, INFO to stdout
+void defaultStatusOutputCallback(const StatusOutputLevel level, const char *format, ...);
+
+// Always output to stderr
+void stdErrStatusOutputCallback(const StatusOutputLevel level, const char *format, ...);
+
+}
+
+#endif

--- a/cplusplus/stringheap.h
+++ b/cplusplus/stringheap.h
@@ -49,4 +49,3 @@ private:
 };
 
 #endif
-

--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -147,7 +147,7 @@ ZDW::ERR_CODE unconvertFile(
 			return ZDW::OK;
 
 		fprintf(stderr, "Error code=%d (%s): ", eRet, UnconvertFromZDW_Base::ERR_CODE_TEXTS[eRet < ZDW::ERR_CODE_COUNT ? eRet : ZDW::ERR_CODE_COUNT]);
-		UnconvertFromZDW_Base::printError(exeName, !filename.empty() ? filename : "from stdin");
+		fprintf(stderr, "%s: %s failed\n\n", exeName, !filename.empty() ? filename.c_str() : "from stdin");
 	}
 
 	return eRet;

--- a/cplusplus/zdw_column_type_constants.h
+++ b/cplusplus/zdw_column_type_constants.h
@@ -38,4 +38,3 @@
 #define VIRTUAL_EXPORT_ROW (65)
 
 #endif
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace printf()/fprintf() calls with a callback for output.  (See cplusplus/status_output.h)
Pretty sure I got the defaults the same as they had been previously.

NOTE: I'm completely open to doing this differently, just let me know.

## Motivation and Context

Still working on bringing my various projects' use of ZDW unconvert in-line with this repo.
Logging is something that I want to be able to easily route through my logger (without, for example, redirecting stdout/stderr) and a simple callback seemed like an easy way to make that happen.

## How Has This Been Tested?

Tested convertDWfile / unconvertDWfile with the included test-files/movie_tickets file

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

Specifically, I made UnconvertDWFile_Base::printError() no longer static.  Which technically could break things.  Though I worked around the only place inside this repo that was using it statically (in unconvertDWfile.cpp)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

