### PR TITLE
Move everything into the adobe::zdw namespace

### DIFF
--- a/cplusplus/BufferedInput.h
+++ b/cplusplus/BufferedInput.h
@@ -20,6 +20,10 @@
 #include <string.h>
 #include <zlib.h>
 
+
+namespace adobe {
+namespace zdw {
+
 class BufferedInput
 {
 public:
@@ -335,5 +339,8 @@ private:
 	bool bFromStdin; //if set, read from stdin instead of 'fp'
 	bool is_gz_file;
 };
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/BufferedOutput.cpp
+++ b/cplusplus/BufferedOutput.cpp
@@ -12,6 +12,10 @@
 
 #include "BufferedOutput.h"
 
+
+namespace adobe {
+namespace zdw {
+
 int compareByIndex(const void* first, const void* second)
 {
 	return (reinterpret_cast<const OutputOrderIndexer *>(first))->index
@@ -23,4 +27,7 @@ int compareByOutputIndex(const void* first, const void* second)
 	return (reinterpret_cast<const OutputOrderIndexer *>(first))->outputIndex
 			- (reinterpret_cast<const OutputOrderIndexer *>(second))->outputIndex;
 }
+
+} // namespace zdw
+} // namespace adobe
 

--- a/cplusplus/BufferedOutput.h
+++ b/cplusplus/BufferedOutput.h
@@ -20,6 +20,10 @@
 #include <string.h>
 #include <string>
 
+
+namespace adobe {
+namespace zdw {
+
 class BufferedOrderedOutput
 {
 private:
@@ -436,5 +440,8 @@ private:
 	bool bUseInternalBuffer;
 	bool bNeedReorder;
 };
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/ConvertToZDW.h
+++ b/cplusplus/ConvertToZDW.h
@@ -20,6 +20,9 @@
 #include <vector>
 
 
+namespace adobe {
+namespace zdw {
+
 //************************************************
 class ConvertToZDW
 {
@@ -68,7 +71,7 @@ public:
 		, m_row(NULL)
 		, m_Version(CONVERT_ZDW_CURRENT_VERSION)
 		, minmaxset(NULL), columnSize(NULL)
-		, statusOutput(ZDW::defaultStatusOutputCallback)
+		, statusOutput(defaultStatusOutputCallback)
 		, bQuiet(bQuiet)
 		, bTrimTrailingSpaces(false)
 		, bStreamingInput(bStreamingInput)
@@ -81,7 +84,7 @@ public:
 		delete[] columnSize;
 	}
 
-	void setStatusOutputCallback(ZDW::StatusOutputCallback cb) { statusOutput = cb; }
+	void setStatusOutputCallback(StatusOutputCallback cb) { statusOutput = cb; }
 
 	void trimTrailingSpaces(bool val = true) { bTrimTrailingSpaces = val; }
 	const char* getInputFileExtension() const { return "sql"; }
@@ -157,10 +160,10 @@ private:
 	std::vector<ULONGLONG> columnMax;
 	char unsigned *columnSize;
 	std::vector<ULONGLONG> columnVal;
-	std::vector<storageBytes> columnStoredVal[2];
+	std::vector<internal::storageBytes> columnStoredVal[2];
 	std::vector<short> usedColumn;
 
-	ZDW::StatusOutputCallback statusOutput;
+	StatusOutputCallback statusOutput;
 
 	const bool bQuiet; //quiet running (no progress output messages)
 	bool bTrimTrailingSpaces;
@@ -168,5 +171,8 @@ private:
 	const bool bStreamingInput; //if set, reading data from stdin
 	FILE *tmp_fp; //used when streaming data in -- stores data for second pass
 };
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/convertDWfile.cpp
+++ b/cplusplus/convertDWfile.cpp
@@ -18,7 +18,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+
+using namespace adobe::zdw;
 using std::strcmp;
+
 
 //******************************************************************
 void showVersion()

--- a/cplusplus/dictionary.cpp
+++ b/cplusplus/dictionary.cpp
@@ -14,6 +14,12 @@
 #include "memory.h"
 #include <cassert>
 
+using namespace adobe::zdw::internal;
+
+
+namespace adobe {
+namespace zdw {
+
 void Dictionary::clear()
 {
 	stringOffsets.clear();
@@ -103,4 +109,7 @@ void Dictionary::write(FILE* f)
 
 	assert(index == bufferSize);
 }
+
+} // namespace zdw
+} // namespace adobe
 

--- a/cplusplus/dictionary.h
+++ b/cplusplus/dictionary.h
@@ -21,7 +21,12 @@
 #include <string>
 
 
-//********************************************************
+namespace adobe {
+namespace zdw {
+
+
+namespace internal {
+
 struct cstringComp
 {
 	bool operator() (const char* const& lhs, const char* const& rhs) const { return std::strcmp(lhs, rhs) < 0; }
@@ -29,6 +34,9 @@ struct cstringComp
 
 typedef std::map<const char*, ULONG, cstringComp> DictionaryT;
 //typedef std::map<std::string, ULONG> DictionaryT; //replaced with custom memory management
+
+} // namespace internal
+
 
 //********************************************************
 class Dictionary
@@ -49,9 +57,12 @@ public:
 	void write(FILE* f); //populates values in stringOffsets
 
 private:
-	DictionaryT stringOffsets;
+	internal::DictionaryT stringOffsets;
 	StringHeap stringHeap;
 	ULONG size;
 };
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/getnextrow.cpp
+++ b/cplusplus/getnextrow.cpp
@@ -15,11 +15,15 @@
 #include <assert.h>
 #include <string.h>
 
+
+namespace adobe {
+namespace zdw {
+
 // Reads a row from the given file into row, of allocated length rowSize.
 // If row is too small to fit the entire line of text, it is reallocated to a larger rowSize.
 //
 //Returns: length of row
-int Common::GetNextRow(
+int GetNextRow(
 	FILE* f,
 	char*& row,   //(in/out) row text
 	ULONG& rowSize) //(in/out) size of longest row encountered so far
@@ -78,4 +82,7 @@ int Common::GetNextRow(
 	assert(len < rowSize); //otherwise we had a buffer overflow above
 	return len;
 }
+
+} // namespace zdw
+} // namespace adobe
 

--- a/cplusplus/getnextrow.h
+++ b/cplusplus/getnextrow.h
@@ -15,8 +15,13 @@
 
 #include "includes.h"
 
-namespace Common {
-	int GetNextRow(FILE* f, char*& row, ULONG& rowSize);
-};
+
+namespace adobe {
+namespace zdw {
+
+int GetNextRow(FILE* f, char*& row, ULONG& rowSize);
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/includes.h
+++ b/cplusplus/includes.h
@@ -35,12 +35,22 @@
 // FIXME: Shift to <cstdint> once on C++11
 #include <stdint.h>
 
+#define DECIMAL_FACTOR_VERSION_1 (1000000000) //version 1
+#define DECIMAL_FACTOR (1000000000000.0)      //version 2-3
+
+
+namespace adobe {
+namespace zdw {
+
 typedef int64_t SLONGLONG;
 typedef uint64_t ULONGLONG;
 
 typedef uint8_t UCHAR;
 typedef uint16_t USHORT;
 typedef uint32_t ULONG;
+
+
+namespace internal {
 
 union indexBytes
 {
@@ -54,9 +64,8 @@ union storageBytes
 	ULONGLONG n;
 };
 
-#define MAX_ULONG (4294967295UL)
-
-#define DECIMAL_FACTOR_VERSION_1 (1000000000) //version 1
-#define DECIMAL_FACTOR (1000000000000.0)      //version 2-3
+} // namespace internal
+} // namespace zdw
+} // namespace adobe
 
 #endif //INCLUDES_H

--- a/cplusplus/memory.cpp
+++ b/cplusplus/memory.cpp
@@ -16,7 +16,16 @@
 
 using std::string;
 
+
+namespace {
+
 const float DEFAULT_PROCESS_MEMORY_THRESHOLD = 3.0f*1024; //in MB
+
+}
+
+
+namespace adobe {
+namespace zdw {
 
 float Memory::memory_threshold_mb = DEFAULT_PROCESS_MEMORY_THRESHOLD;
 
@@ -70,4 +79,7 @@ bool Memory::CanAllocateMemory(const long long unsigned memNeeded)
 
 	return process_memory_usage() + memNeededMB < get_memory_usage_limit_MB();
 }
+
+} // namespace zdw
+} // namespace adobe
 

--- a/cplusplus/memory.h
+++ b/cplusplus/memory.h
@@ -13,6 +13,10 @@
 #ifndef MEMORY_H
 #define MEMORY_H
 
+
+namespace adobe {
+namespace zdw {
+
 class Memory
 {
 	Memory(); //unimplemented
@@ -26,5 +30,8 @@ public:
 	static double process_memory_usage();
 	static bool set_memory_threshold_MB(const float mb);
 };
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/status_output.cpp
+++ b/cplusplus/status_output.cpp
@@ -15,7 +15,8 @@
 #include <stdio.h>
 
 
-namespace ZDW {
+namespace adobe {
+namespace zdw {
 
 // ERROR to stderr, INFO to stdout
 void defaultStatusOutputCallback(const StatusOutputLevel level, const char *format, ...)
@@ -39,5 +40,6 @@ void stdErrStatusOutputCallback(const StatusOutputLevel level, const char *forma
 	va_end(argptr);
 }
 
-}
+} // namespace zdw
+} // namespace adobe
 

--- a/cplusplus/status_output.h
+++ b/cplusplus/status_output.h
@@ -14,7 +14,8 @@
 #define ZDW_STATUS_OUTPUT_H
 
 
-namespace ZDW {
+namespace adobe {
+namespace zdw {
 
 enum StatusOutputLevel
 {
@@ -31,6 +32,7 @@ void defaultStatusOutputCallback(const StatusOutputLevel level, const char *form
 // Always output to stderr
 void stdErrStatusOutputCallback(const StatusOutputLevel level, const char *format, ...);
 
-}
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/stringheap.cpp
+++ b/cplusplus/stringheap.cpp
@@ -17,7 +17,16 @@
 #include <cstring>
 #include <stdio.h>
 
+
+namespace {
+
 const size_t HEAP_BLOCK_SIZE = 64 * 1024 * 1024;
+
+}
+
+
+namespace adobe {
+namespace zdw {
 
 char* StringHeap::copyToHeap(const char* str, const size_t len)
 {
@@ -89,4 +98,7 @@ void StringHeap::FreeMemory()
 
 	this->low_on_memory = false;
 }
+
+} // namespace zdw
+} // namespace adobe
 

--- a/cplusplus/stringheap.h
+++ b/cplusplus/stringheap.h
@@ -17,6 +17,9 @@
 #include <cstring>
 
 
+namespace adobe {
+namespace zdw {
+
 class StringHeap
 {
 public:
@@ -47,5 +50,8 @@ private:
 
 	bool low_on_memory;
 };
+
+} // namespace zdw
+} // namespace adobe
 
 #endif

--- a/cplusplus/test_unconvert_api.cpp
+++ b/cplusplus/test_unconvert_api.cpp
@@ -19,6 +19,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+using namespace std;
+
+
 //*****************************
 void ShowHelp(char* executable)
 {

--- a/cplusplus/test_unconvert_api.cpp
+++ b/cplusplus/test_unconvert_api.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 
 using namespace std;
+using namespace adobe::zdw;
 
 
 //*****************************
@@ -49,7 +50,8 @@ void processLine(const char** outColumns, size_t numColumns)
 	printf("\n");
 }
 
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[])
+{
 	int fileBeginIndex = 1;
 	if (argc < 2)
 	{
@@ -67,7 +69,6 @@ int main(int argc, char* argv[]) {
 		}
 		namesOfColumnsToOutput = argv[2];
 		fileBeginIndex = 3;
-
 	}
 
 	//Each iteration unconverts one ZDW input file.
@@ -76,13 +77,13 @@ int main(int argc, char* argv[]) {
 		UnconvertFromZDWToMemory unconvert(argv[i], false); //test in-memory API
 		if (!namesOfColumnsToOutput.empty())
 		{
-			unconvert.setNamesOfColumnsToOutput(namesOfColumnsToOutput, ZDW::SKIP_INVALID_COLUMN);
+			unconvert.setNamesOfColumnsToOutput(namesOfColumnsToOutput, SKIP_INVALID_COLUMN);
 		}
 
-		ZDW::ERR_CODE eRet;
+		ERR_CODE eRet;
 
 		eRet = unconvert.readHeader();
-		if (eRet != ZDW::OK)
+		if (eRet != OK)
 		{
 			fprintf(stderr, "Error %i\n", eRet);
 			return eRet;
@@ -93,7 +94,7 @@ int main(int argc, char* argv[]) {
 
 		size_t numColumns;
 		eRet = unconvert.getNumOutputColumns(numColumns);
-		if (eRet != ZDW::OK)
+		if (eRet != OK)
 		{
 			fprintf(stderr, "Error %i\n", eRet);
 			return eRet;
@@ -107,10 +108,10 @@ int main(int argc, char* argv[]) {
 		while (!unconvert.isFinished()) {
 			eRet = unconvert.getRow(&buffer, &lineLength, outColumns, numColumns);
 			switch (eRet) {
-				case ZDW::OK:
+				case OK:
 					processLine(outColumns, numColumns);
 					break;
-				case ZDW::AT_END_OF_FILE:
+				case AT_END_OF_FILE:
 					//successful completion
 					assert(unconvert.isFinished());
 					break;

--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <algorithm>
 
+using namespace adobe::zdw;
 using std::string;
 
 
@@ -80,7 +81,7 @@ int badParam(char* exeName, const char* paramStr)
 {
 	fprintf(stderr, "%s: Unknown parameter '%s'\n\n", exeName, paramStr);
 	fprintf(stderr, "    Run with --help for usage info.\n");
-	return ZDW::BAD_PARAMETER;
+	return BAD_PARAMETER;
 }
 
 //************************************
@@ -89,24 +90,24 @@ int missingParam(char* exeName, const char* paramStr)
 {
 	fprintf(stderr, "%s: Missing argument after parameter '%s'\n\n", exeName, paramStr);
 	fprintf(stderr, "    Run with --help for usage info.\n");
-	return ZDW::BAD_PARAMETER;
+	return BAD_PARAMETER;
 }
 
 int extraOption(char* exeName, const char* optionStr)
 {
 	fprintf(stderr, "%s: Extra option '%s' not allowed in tandem with other mutually exclusive options.\n\n", exeName, optionStr);
 	fprintf(stderr, "    Run with --help for usage info.\n");
-	return ZDW::BAD_PARAMETER;
+	return BAD_PARAMETER;
 }
 
 int emptyFilename(char* exeName)
 {
 	fprintf(stderr, "%s: Empty filename not allowed\n\n", exeName);
 	fprintf(stderr, "    Run with --help for usage info.\n");
-	return ZDW::BAD_PARAMETER;
+	return BAD_PARAMETER;
 }
 //********************************************
-ZDW::ERR_CODE unconvertFile(
+ERR_CODE unconvertFile(
 	string const& filename,
 	const string& outputFileExtension,
 	const string& namesOfColumnsToOutput,
@@ -118,12 +119,12 @@ ZDW::ERR_CODE unconvertFile(
 	bool bTestOnly,
 	bool bOutputDescFileOnly,
 	bool bToStdout,
-	ZDW::COLUMN_INCLUSION_RULE columnInclusionRule,
+	COLUMN_INCLUSION_RULE columnInclusionRule,
 	bool bShowBasicStatisticsOnly)
 {
 	assert(exeName);
 
-	ZDW::ERR_CODE eRet = ZDW::OK;
+	ERR_CODE eRet = OK;
 	if (namesOfColumnsToOutput.empty() || bShowBasicStatisticsOnly) {
 		UnconvertFromZDWToFile<BufferedOutput> unconvertFromZDW(filename, bShowStatus, bQuiet, bTestOnly, bOutputDescFileOnly);
 		if (bShowBasicStatisticsOnly)
@@ -133,20 +134,20 @@ ZDW::ERR_CODE unconvertFile(
 		UnconvertFromZDWToFile<BufferedOrderedOutput> unconvertFromZDW(filename, bShowStatus, bQuiet, bTestOnly, bOutputDescFileOnly);
 		const bool bRes = unconvertFromZDW.setNamesOfColumnsToOutput(namesOfColumnsToOutput, columnInclusionRule);
 		if (!bRes)
-			eRet = ZDW::BAD_REQUESTED_COLUMN;
+			eRet = BAD_REQUESTED_COLUMN;
 		else
 			eRet = unconvertFromZDW.unconvert(exeName, outputBasename, outputFileExtension.c_str(), specifiedDir, bToStdout);
 	}
 
 	//Abnormal termination?
-	if (eRet != ZDW::OK) {
+	if (eRet != OK) {
 		//None of the requested columns were outputted.
 		//If we're only looking at the file schema, return with no error.
 		//Otherwise, the error code will inform that no data values are coming back.
-		if (eRet == ZDW::NO_COLUMNS_TO_OUTPUT && bOutputDescFileOnly)
-			return ZDW::OK;
+		if (eRet == NO_COLUMNS_TO_OUTPUT && bOutputDescFileOnly)
+			return OK;
 
-		fprintf(stderr, "Error code=%d (%s): ", eRet, UnconvertFromZDW_Base::ERR_CODE_TEXTS[eRet < ZDW::ERR_CODE_COUNT ? eRet : ZDW::ERR_CODE_COUNT]);
+		fprintf(stderr, "Error code=%d (%s): ", eRet, UnconvertFromZDW_Base::ERR_CODE_TEXTS[eRet < ERR_CODE_COUNT ? eRet : ERR_CODE_COUNT]);
 		fprintf(stderr, "%s: %s failed\n\n", exeName, !filename.empty() ? filename.c_str() : "from stdin");
 	}
 
@@ -164,7 +165,7 @@ int main(int argc, char* argv[])
 	bool bOutputDescFileOnly = false;
 	bool bTestOnly = false;
 	bool bQuiet = false;
-	ZDW::COLUMN_INCLUSION_RULE inclusionRule = ZDW::FAIL_ON_INVALID_COLUMN;
+	COLUMN_INCLUSION_RULE inclusionRule = FAIL_ON_INVALID_COLUMN;
 	bool bShowBasicStatisticsOnly = false;
 	string defaultExtension = ".sql";
 	string namesOfColumnsToOutput;
@@ -230,10 +231,10 @@ int main(int argc, char* argv[])
 					break;
 				case 'c':
 					switch (argv[i][2]) {
-						case 'e': inclusionRule = ZDW::PROVIDE_EMPTY_MISSING_COLUMNS; break;
-						case 'i': inclusionRule = ZDW::SKIP_INVALID_COLUMN; break;
-						case 'x': inclusionRule = ZDW::EXCLUDE_SPECIFIED_COLUMNS; break;
-						case '\0': default: inclusionRule = ZDW::FAIL_ON_INVALID_COLUMN; break;
+						case 'e': inclusionRule = PROVIDE_EMPTY_MISSING_COLUMNS; break;
+						case 'i': inclusionRule = SKIP_INVALID_COLUMN; break;
+						case 'x': inclusionRule = EXCLUDE_SPECIFIED_COLUMNS; break;
+						case '\0': default: inclusionRule = FAIL_ON_INVALID_COLUMN; break;
 					}
 					namesOfColumnsToOutput = argv[++i];
 					break;
@@ -274,11 +275,11 @@ int main(int argc, char* argv[])
 						else if (!strcmp(flag, "help"))
 						{
 							ShowHelp(argv[0]);
-							return ZDW::OK;
+							return OK;
 						}
 						else if (!strcmp(flag, "ver") || !strcmp(flag, "version")) {
 							showVersion();
-							return ZDW::OK;
+							return OK;
 						}
 					}
 					//any other "--text" param is invalid
@@ -319,7 +320,7 @@ int main(int argc, char* argv[])
 					outputFileExtension += ext;
 
 				//Process a file.
-				ZDW::ERR_CODE eRet = unconvertFile(
+				ERR_CODE eRet = unconvertFile(
 					argv[i], outputFileExtension, namesOfColumnsToOutput, specifiedDir.c_str(),
 					NULL, //output basename is the same as of the input filename
 					argv[0],
@@ -327,7 +328,7 @@ int main(int argc, char* argv[])
 					inclusionRule,
 					bShowBasicStatisticsOnly
 				);
-				if (eRet != ZDW::OK)
+				if (eRet != OK)
 					return eRet;
 			}
 		}
@@ -341,7 +342,7 @@ int main(int argc, char* argv[])
 		if (ext)
 			outputFileExtension = ext;
 
-		ZDW::ERR_CODE eRet = unconvertFile(
+		ERR_CODE eRet = unconvertFile(
 			"", //indicates to read data from stdin
 			outputFileExtension, namesOfColumnsToOutput, specifiedDir.c_str(),
 			outputBasename, //an output filename might be set
@@ -350,9 +351,10 @@ int main(int argc, char* argv[])
 			inclusionRule,
 			bShowBasicStatisticsOnly
 		);
-		if (eRet != ZDW::OK)
+		if (eRet != OK)
 			return eRet;
 	}
 
-	return ZDW::OK;
+	return OK;
 }
+


### PR DESCRIPTION


## Description

Essentially just encapsulate near everything inside:
`namespace adobe { namespace zdw { ... } }`

Note: A small handfull of things went into adobe::zdw::internal or an anonymous namespace

## Related Issue

See Issue #8 

## How Has This Been Tested?

Tested with test-files/movie_tickets file

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
