### PR TITLE
[ISSUE-12] Force date-time parsing to use UTC since original timezone is unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ SQL column types.  The list of supported types are:
 |-----------|-------------|-----------------|----------------|
 | VARCHAR | 0 | String | StringType |
 | TEXT | 1 | String | StringType |
-| DATETIME | 2 | java.util.Date | TimestampType |
+| DATETIME | 2 | java.util.Date in UTC timezone | TimestampType |
 | CHAR_2 | 3 | String | StringType |
 | CHAR | 6 | String | StringType |
 | TINY | 7 | Short | ShortType |

--- a/format/src/main/scala/com/adobe/analytics/zdw/format/ZDWBlock.scala
+++ b/format/src/main/scala/com/adobe/analytics/zdw/format/ZDWBlock.scala
@@ -14,6 +14,7 @@ package com.adobe.analytics.zdw.format
 import java.io.DataInputStream
 import java.nio.charset.{Charset, StandardCharsets}
 import java.text.SimpleDateFormat
+import java.util.TimeZone
 
 import scala.collection.mutable
 
@@ -57,7 +58,12 @@ case class ZDWBlock(
   private[this] val newValueFlagsBytes = new Array[Byte](newValueFlagsNumBytes)
   private[this] val prevColumnValues = new Array[Any](header.columns.size)
 
-  private[this] val dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+  private[this] val dateTimeFormat = {
+    val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    // Always parse date-time string values as UTC because there isn't a defined timezone
+    format.setTimeZone(TimeZone.getTimeZone("UTC"))
+    format
+  }
 
   override def hasNext: Boolean = rowNum < numRows
 

--- a/format/src/test/scala/com/adobe/analytics/zdw/format/ZDWStreamIteratorTest.scala
+++ b/format/src/test/scala/com/adobe/analytics/zdw/format/ZDWStreamIteratorTest.scala
@@ -13,7 +13,7 @@ package com.adobe.analytics.zdw.format
 
 import java.io._
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.{Date, TimeZone}
 
 import scala.collection.JavaConverters._
 
@@ -53,7 +53,11 @@ class ZDWStreamIteratorTest extends BasicSpec {
   }
 
   // Recreate the formatting unconvertDWfile would have done
-  private[this] val sqlValueDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+  private[this] val sqlValueDateFormat = {
+    val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    format.setTimeZone(TimeZone.getTimeZone("UTC"))
+    format
+  }
   private[this] def toSQLValueString(value: Any): String = {
     value match {
       case isNull if isNull == null => ""

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,8 @@
             </execution>
           </executions>
           <configuration>
-            <argLine>-Xmx1024m</argLine>
+            <!-- Force timezone to try and catch any local timezone assumptions -->
+            <argLine>-Xmx1024m -Duser.timezone=Europe/Bucharest</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
This addresses issue #12 

## Description

The approach to fixing the timezone issue is to force the date-time parsing to always use UTC so we're still providing a type specific object for date-time fields but not making any assumptions on the local timezone.  The user will need to handle any timezone shifting.

## Related Issue

Issue #12 

## Motivation and Context

Removed local timezone assumptions.

## How Has This Been Tested?

Changed scalatests to use non hour aligned timezone and use existing tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.