### PR TITLE
Add default constructor to MetadataOptions

### DIFF
--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -190,7 +190,7 @@ int main(int argc, char* argv[])
 	string defaultExtension = ".sql";
 	string namesOfColumnsToOutput;
 
-	internal::MetadataOptions metadataOptions = {false, false, false};
+	internal::MetadataOptions metadataOptions;
 
 	if (argc < 2)
 	{

--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -91,6 +91,11 @@ struct MetadataOptions
 	bool bOnlyMetadataKeys;
 	bool bAllowMissingKeys;
 	std::set<std::string> keys;
+
+	MetadataOptions() :
+		bOutputOnlyMetadata(false),
+		bOnlyMetadataKeys(false),
+		bAllowMissingKeys(false) { }
 };
 
 } // namespace internal


### PR DESCRIPTION
Using the UnconvertFromZDW object without explicitly setting up a
MetadataOptions object is undefined/unspecified behavior (due to the
uninitialized options fields).  Let's just pick some sane defaults
rather than leaving this landmine in the code.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

