### PR TITLE
Add a getVersion() method to UnconvertFromZDW_Base

### DIFF
--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <math.h>
 #include <ostream>
+#include <sstream>
 #include <algorithm>
 #include <set>
 #include "zdw_column_type_constants.h"
@@ -251,6 +252,13 @@ UnconvertFromZDW_Base::~UnconvertFromZDW_Base()
 	delete[] this->outputColumns;
 	delete[] this->row;
 	delete this->input;
+}
+
+string UnconvertFromZDW_Base::getVersion()
+{
+	std::ostringstream str;
+	str << UNCONVERT_ZDW_VERSION << UNCONVERT_ZDW_VERSION_TAIL;
+	return str.str();
 }
 
 //**********************************************

--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -104,6 +104,8 @@ public:
 
 	void setStatusOutputCallback(StatusOutputCallback cb) { statusOutput = cb; }
 
+	static std::string getVersion();
+
 	//Common API.
 	std::vector<std::string> getColumnNames() const { return this->columnNames; }
 	UCHAR* getColumnTypes() const { return this->columnType; }


### PR DESCRIPTION
## Description

I would like a simple getVersion() to call which will return something fairly human readable, to put into my /version endpoints.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
