### PR TITLE
Sync public zdw repo with internal changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ SQL column types.  The list of supported types are:
 |-----------|-------------|-----------------|----------------|
 | VARCHAR | 0 | String | StringType |
 | TEXT | 1 | String | StringType |
-| DATETIME | 2 | java.util.Date | TimestampType |
+| DATETIME | 2 | java.util.Date in UTC timezone | TimestampType |
 | CHAR_2 | 3 | String | StringType |
 | CHAR | 6 | String | StringType |
 | TINY | 7 | Short | ShortType |

--- a/cplusplus/ConvertToZDW.cpp
+++ b/cplusplus/ConvertToZDW.cpp
@@ -70,8 +70,8 @@ inline bool dump_trimmed_row_to_temp_file(FILE* fp, const vector<char*>& rowColu
 namespace adobe {
 namespace zdw {
 
-int ConvertToZDW::CONVERT_ZDW_CURRENT_VERSION = 10; //TODO temp non-const for version 11 migration
-const char ConvertToZDW::CONVERT_ZDW_VERSION_TAIL[3] = "a";
+const int ConvertToZDW::CONVERT_ZDW_CURRENT_VERSION = 11;
+const char ConvertToZDW::CONVERT_ZDW_VERSION_TAIL[3] = "";
 
 const char ConvertToZDW::ERR_CODE_TEXTS[ERR_CODE_COUNT][30] = {
 	"OK","NO_ARGS","CONVERSION_FAILED","UNTAR_FAILED","MISSING_DESC_FILE","MISSING_SQL_FILE",
@@ -623,12 +623,6 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 		statusOutput(ERROR, "Invalid metadata parameter\n");
 		return BAD_METADATA_PARAM;
 	}
-	if (!metadata.empty() && CONVERT_ZDW_CURRENT_VERSION < 11)
-	{
-		//TODO remove post v11 migration
-		statusOutput(ERROR, "Metadata values are not supported before version 11\n");
-		return BAD_METADATA_PARAM;
-	}
 
 	string zdwFile;
 
@@ -678,7 +672,6 @@ ConvertToZDW::ERR_CODE ConvertToZDW::processFile(
 	fwrite(&m_Version, 1, 2, out);
 
 	//Write metadata block.
-	if (CONVERT_ZDW_CURRENT_VERSION == 11) //TODO temp feature flag hack for migration from version 10 to version 11
 	{
 		ULONG metadata_length = 0;
 		map<string, string>::const_iterator it;
@@ -997,7 +990,7 @@ ConvertToZDW::ERR_CODE ConvertToZDW::convertFile(
 	fclose(in);
 
 	map<string, string> inMetadata = metadata;
-	if (inMetadata.empty() && CONVERT_ZDW_CURRENT_VERSION >= 11) {
+	if (inMetadata.empty()) {
 		//Default to .metadata file contents, if present.
 		sprintf(command, "%s.metadata", filestub);
 		const int res = loadMetadataFile(command, inMetadata);

--- a/cplusplus/ConvertToZDW.h
+++ b/cplusplus/ConvertToZDW.h
@@ -29,7 +29,7 @@ class ConvertToZDW
 {
 public:
 	//Version info
-	static int CONVERT_ZDW_CURRENT_VERSION; //TODO temp non-const for version11 migration
+	static const int CONVERT_ZDW_CURRENT_VERSION;
 	static const char CONVERT_ZDW_VERSION_TAIL[3];
 
 	enum Compressor {
@@ -86,9 +86,6 @@ public:
 		delete[] minmaxset;
 		delete[] columnSize;
 	}
-
-	//TODO Temporary feature flag for migration to version 11 -- remove after migration
-	void enableVersion11() { m_Version = CONVERT_ZDW_CURRENT_VERSION = 11; }
 
 	void setStatusOutputCallback(StatusOutputCallback cb) { statusOutput = cb; }
 

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -216,11 +216,9 @@ UnconvertFromZDW_Base::UnconvertFromZDW_Base(const string &fileName,
 			string cmd;
 			const size_t len = inFileName.size();
 			if (len >= 4 && !strcmp(inFileName.c_str() + len - 3, ".gz")) {
-				//Internal uncompression of .gz files.
-				input = new BufferedInput(inFileName.c_str(), 16*1024, true);
-				return;
-			}
-			if (len >= 5 && !strcmp(inFileName.c_str() + len - 4, ".bz2")) {
+				cmd = "zcat ";
+				cmd += inFileName;
+			} else if (len >= 5 && !strcmp(inFileName.c_str() + len - 4, ".bz2")) {
 				//Streaming uncompression of .bz2 files.
 				cmd = "bzip2 -d --stdout ";
 				cmd += inFileName;
@@ -234,7 +232,7 @@ UnconvertFromZDW_Base::UnconvertFromZDW_Base(const string &fileName,
 				cmd += inFileName;
 			}
 
-			input = new BufferedInput(cmd.c_str());
+			input = new BufferedInput(cmd);
 		}
 	} else {
 		//No filename specified -- read ZDW data from stdin.

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -218,6 +218,7 @@ UnconvertFromZDW_Base::UnconvertFromZDW_Base(const string &fileName,
 			if (len >= 4 && !strcmp(inFileName.c_str() + len - 3, ".gz")) {
 				cmd = "zcat ";
 				cmd += inFileName;
+				cmd.append(" 2>/dev/null"); //we don't need to see any chatter -- we output all relevant error codes ourselves
 			} else if (len >= 5 && !strcmp(inFileName.c_str() + len - 4, ".bz2")) {
 				//Streaming uncompression of .bz2 files.
 				cmd = "bzip2 -d --stdout ";

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <math.h>
 #include <ostream>
+#include <sstream>
 #include <algorithm>
 #include <set>
 #include "zdw_column_type_constants.h"
@@ -251,6 +252,13 @@ UnconvertFromZDW_Base::~UnconvertFromZDW_Base()
 	delete[] this->outputColumns;
 	delete[] this->row;
 	delete this->input;
+}
+
+string UnconvertFromZDW_Base::getVersion()
+{
+	std::ostringstream str;
+	str << UNCONVERT_ZDW_VERSION << UNCONVERT_ZDW_VERSION_TAIL;
+	return str.str();
 }
 
 //**********************************************

--- a/cplusplus/convertDWfile.cpp
+++ b/cplusplus/convertDWfile.cpp
@@ -55,7 +55,6 @@ void usage(const char* executable)
 		"\t--zargs=X          arguments to pass in to the file compression process\n"
 		"\t--mem-limit=<MB>   limit the MB of RAM used (default=3072 MB)\n"
 		"\n"
-		"\t--version11                feature flag to enable creation of v11 file format (i.e., w/ metadata block in header)\n"
 		"\t--metadata:<key>=<value>   supply a key-value pair to store as file metadata for every file being converted\n"
 		"\t--metadata-file=<filename> supply a filepath to specify key-value pairs (formatted as '<key>=<value>' pairs, each on a separate line) to store as file metadata for every file being converted\n"
 		"\n"
@@ -113,7 +112,6 @@ int main(int argc, char* argv[])
 	const char* pOutputDir = NULL; //default = current dir
 	const char* zArgs = NULL;
 	map<string, string> metadata;
-	bool bVersion11EnableFlag = false; //TODO temp feature flag for version 10 migration -- remove on completion
 
 	//Parse flags.
 	int i;
@@ -177,11 +175,6 @@ int main(int argc, char* argv[])
 							zArgs = flag + 6;
 							break;
 						}
-						if (!strcmp(flag, "version11"))
-						{
-							bVersion11EnableFlag = true;
-							break;
-						}
 					}
 					//any other "--text" param is invalid
 					usage(program);
@@ -222,8 +215,6 @@ int main(int argc, char* argv[])
 			char filestub[1024];
 			ConvertToZDW convert(bQuiet, bStreamingInput);
 			convert.compressor = compressor;
-			if (bVersion11EnableFlag)
-				convert.enableVersion11();
 			if (trimTrailingSpaces)
 				convert.trimTrailingSpaces();
 			const ConvertToZDW::ERR_CODE res = convert.convertFile(argv[i], program, validate, filestub, pOutputDir, zArgs, metadata);

--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -13,10 +13,10 @@
 #ifndef UNCONVERTFROMZDW_H
 #define UNCONVERTFROMZDW_H
 
-#include "zdw/includes.h"
-#include "zdw/BufferedInput.h"
-#include "zdw/BufferedOutput.h"
-#include "zdw/status_output.h"
+#include "includes.h"
+#include "BufferedInput.h"
+#include "BufferedOutput.h"
+#include "status_output.h"
 
 #include <map>
 #include <string>

--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -104,6 +104,8 @@ public:
 
 	void setStatusOutputCallback(StatusOutputCallback cb) { statusOutput = cb; }
 
+	static std::string getVersion();
+
 	//Common API.
 	std::vector<std::string> getColumnNames() const { return this->columnNames; }
 	UCHAR* getColumnTypes() const { return this->columnType; }

--- a/format/src/main/scala/com/adobe/analytics/zdw/format/ZDWBlock.scala
+++ b/format/src/main/scala/com/adobe/analytics/zdw/format/ZDWBlock.scala
@@ -14,6 +14,7 @@ package com.adobe.analytics.zdw.format
 import java.io.DataInputStream
 import java.nio.charset.{Charset, StandardCharsets}
 import java.text.SimpleDateFormat
+import java.util.TimeZone
 
 import scala.collection.mutable
 
@@ -57,7 +58,12 @@ case class ZDWBlock(
   private[this] val newValueFlagsBytes = new Array[Byte](newValueFlagsNumBytes)
   private[this] val prevColumnValues = new Array[Any](header.columns.size)
 
-  private[this] val dateTimeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+  private[this] val dateTimeFormat = {
+    val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    // Always parse date-time string values as UTC because there isn't a defined timezone
+    format.setTimeZone(TimeZone.getTimeZone("UTC"))
+    format
+  }
 
   override def hasNext: Boolean = rowNum < numRows
 

--- a/format/src/test/scala/com/adobe/analytics/zdw/format/ZDWStreamIteratorTest.scala
+++ b/format/src/test/scala/com/adobe/analytics/zdw/format/ZDWStreamIteratorTest.scala
@@ -13,7 +13,7 @@ package com.adobe.analytics.zdw.format
 
 import java.io._
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.{Date, TimeZone}
 
 import scala.collection.JavaConverters._
 
@@ -53,7 +53,11 @@ class ZDWStreamIteratorTest extends BasicSpec {
   }
 
   // Recreate the formatting unconvertDWfile would have done
-  private[this] val sqlValueDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+  private[this] val sqlValueDateFormat = {
+    val format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss")
+    format.setTimeZone(TimeZone.getTimeZone("UTC"))
+    format
+  }
   private[this] def toSQLValueString(value: Any): String = {
     value match {
       case isNull if isNull == null => ""

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,8 @@
             </execution>
           </executions>
           <configuration>
-            <argLine>-Xmx1024m</argLine>
+            <!-- Force timezone to try and catch any local timezone assumptions -->
+            <argLine>-Xmx1024m -Duser.timezone=Europe/Bucharest</argLine>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Synchronizes changes with the internal zdw repo.  Changes from master/v11 on the public side have been pulled into the internal repo, and changes on the internal repo are being propegated to the v11 external branch.

**This should be _merged_, not _rebased_, since we needed to synchronize with master.**

After this is merged, we can merge v11 into master and make v11 official.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

