### PR TITLE
Remove getrow; make getline public

### DIFF
--- a/cplusplus/zdw/BufferedInput.h
+++ b/cplusplus/zdw/BufferedInput.h
@@ -283,6 +283,7 @@ public:
 		return out_pos ? buf : NULL;
 	}
 
+private:
 	std::string command;
 	FILE* fp;
 	char *buffer;

--- a/cplusplus/zdw/BufferedInput.h
+++ b/cplusplus/zdw/BufferedInput.h
@@ -108,34 +108,6 @@ public:
 		} while (this->length < this->capacity && !this->bEOF);
 	}
 
-	//Stitch together multiple lines of text with embedded newlines
-	const char* getrow(char *row, int rowSize)
-	{
-		int len = 0;
-
-		for (;;)
-		{
-			const char *str = this->getline(row + len, rowSize - len);
-			if (!str)
-				return len ? row : NULL;
-
-			len += strlen(str);
-			if (len >= rowSize)
-				break; //buffer is full -- can't read in any more data
-
-			if (row[len - 1] != '\n') //no potentially embedded newline to check for
-				break;
-
-			int e = 2; //walk backwards from the character before observed newline
-			while (e <= len && row[len - e] == '\\')
-				++e;
-			if (!(e % 2)) //odd number (of preceding backslashes) indicates embedded newline -- need to read more of the row
-				break;
-		}
-
-		return row;
-	}
-
 	//Returns: number of bytes read
 	size_t read(void* data, size_t size)
 	{
@@ -271,7 +243,15 @@ public:
 		return false;
 	}
 
-private:
+	// Obtains a line of data (or as much of a line as can fit) into the supplied buffer.
+	//
+	// If there isn't enough data in the buffer for the entire line, as much of the line as possible will be stored
+	// in the buffer, including a null terminator.
+	//
+	// The filled buffer will include newline termination, if there is newline termination available (e.g., a
+	// line at the end of the file with no terminating newline will result in a buffer without newline termination)
+	//
+	// Returns a pointer to the filled buffer or nullptr if there is no more data to read into the buffer.
 	const char* getline(char* buf, const size_t size)
 	{
 		assert(buf);


### PR DESCRIPTION
Syncs with changes to internal copy; removes the getrow function (which
was moved to another module internally), and (better) documents the
intended behavior of getline.

Getline is now public, so other places can build on top of it.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

