### PR TITLE
Remove exit() from UnconvertFromZDW_Base::readyBytes() in favor of new ZDWException class

### DIFF
--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <vector>
 #include <sys/stat.h>
@@ -61,6 +62,14 @@ enum COLUMN_INCLUSION_RULE
 	SKIP_INVALID_COLUMN,
 	EXCLUDE_SPECIFIED_COLUMNS,
 	PROVIDE_EMPTY_MISSING_COLUMNS
+};
+
+
+class ZDWException : public std::runtime_error
+{
+public:
+	explicit ZDWException(const ERR_CODE errcode);
+	ERR_CODE code;
 };
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

There was a call to exit() in library code!  Switching to an exception makes it more recoverable.
While technically the exception is going to be different than the call to exit(), for existing code, it should work the same (instead terminate with uncaught excpetion), unless std::runtime_error is being caught somewhere along the call stack, in which case it'll change the behavior, perhaps even in a semi-breaking way?

## How Has This Been Tested?

Ran both the movie-tickets and analytics-hits through the converter/validation/unconverter

## Screenshots (if appropriate):

## Types of changes

- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ x ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
