### PR TITLE
Fix double-free bug in UnconvertFromZDW_Base::readBytes() when we throw

### DIFF
--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -285,6 +285,7 @@ size_t UnconvertFromZDW_Base::readBytes(
 	{
 		printError(this->exeName, getInputFilename(this->inFileName));
 		delete this->input;
+		this->input = NULL;
 		throw ZDWException(GZREAD_FAILED);
 	}
 	return result;


### PR DESCRIPTION

## Description

If/when we hit the throw in UnconvertFromZDW_Base::readBytes(), it leads to a double-free (on this->input) when the class is destructed.

## Motivation and Context

I removed the exit() so that I could handle failures better.  Trading the exit() for a double-free was not my intention!

## How Has This Been Tested?

Ran both the movie-tickets and analytics-hits through the converter/validation/unconverter
Also, I have a process that was semi-routinely hitting the throw and subsequently segfaulting.  That seems to have stopped with this fix.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

