### PR TITLE
Migrate a bunch of code from public header files into cpp files

### DIFF
--- a/cplusplus/BufferedInput.cpp
+++ b/cplusplus/BufferedInput.cpp
@@ -1,0 +1,275 @@
+/**
+ * Copyright 2019 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+#include "zdw/BufferedInput.h"
+#include <cassert>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <zlib.h>
+
+
+namespace adobe {
+namespace zdw {
+
+// open a pipe via a command and read input from the pipe
+BufferedInput::BufferedInput(const std::string& command, const size_t capacity)
+	: command(command)
+	, fp(NULL)
+	, buffer(NULL)
+	, capacity(capacity)
+	, index(0), length(0)
+	, bEOF(false)
+	, bFromStdin(false)
+{
+	open();
+}
+
+// read from standard input
+BufferedInput::BufferedInput()
+	: fp(NULL)
+	, buffer(NULL)
+	, capacity(0)
+	, index(0), length(0)
+	, bEOF(false)
+	, bFromStdin(true)
+{ }
+
+BufferedInput::~BufferedInput()
+{
+	close();
+	delete[] buffer;
+}
+
+void BufferedInput::close()
+{
+	if (fp) {
+		pclose(fp);
+		fp = NULL;
+	}
+}
+
+bool BufferedInput::rewind()
+{
+	bEOF = false;
+	index = length = 0;
+	assert(!command.empty());
+	close();
+	return open();
+}
+
+//Returns: whether any more data can be returned
+bool BufferedInput::eof() const
+{
+	if (this->bFromStdin) {
+		return feof(stdin) != 0;
+	} else {
+		return bEOF && index >= length;
+	}
+}
+
+bool BufferedInput::can_read_more_data() const
+{
+	if (eof()) {
+		return false;
+	}
+	return this->fp != NULL;
+}
+
+void BufferedInput::refill_buffer()
+{
+	this->index = this->length = 0;
+	do {
+		//Iterate reads when we don't receive the entire buffer immediately.
+		this->length += fread(this->buffer + this->length,
+				1, this->capacity - this->length, this->fp);
+		this->bEOF = feof(this->fp) != 0;
+	} while (this->length < this->capacity && !this->bEOF);
+}
+
+//Returns: number of bytes read
+size_t BufferedInput::read(void* data, size_t size)
+{
+	if (this->bFromStdin) {
+		//Reads requested number of bytes from stdin.
+		return fread(data, 1, size, stdin);
+	}
+
+	if (!can_read_more_data()) {
+		return 0;
+	}
+
+	size_t bytesRead = 0;
+
+	//Asking for more data than is currently in the buffer?
+	size_t bytesInBuffer = this->length - this->index;
+	if (size > bytesInBuffer) {
+		//Flush what is available first.
+		if (bytesInBuffer) {
+			memcpy(data, this->buffer + this->index, bytesInBuffer);
+
+			//If we've hit EOF, then there is no more data to read in.
+			if (this->bEOF) {
+				return bytesInBuffer;
+			}
+
+			//Prepare to fill the output buffer with more data.
+			size -= bytesInBuffer;
+			data = static_cast<char*>(data) + bytesInBuffer;
+			bytesRead = bytesInBuffer;
+		}
+
+		//Should we read more into the buffer for this call?
+		if (size >= this->capacity) {
+			//Buffer is not large enough to store the rest of the requested data.
+			//Just pass the rest of the data through without buffering.
+			bytesRead += fread(data, 1, size, this->fp);
+			this->bEOF = feof(this->fp) != 0;
+
+			//Buffer is now empty -- refill next call
+			this->index = this->length = 0;
+
+			return bytesRead;
+		}
+
+		refill_buffer();
+		bytesInBuffer = this->length;
+	}
+
+	//Return the amount of data requested.
+	//If there isn't enough data available to fill the request, return what's left
+	if (size > bytesInBuffer) {
+		size = bytesInBuffer;
+	}
+	memcpy(data, this->buffer + this->index, size);
+	this->index += size;
+
+	return bytesRead + size; //total bytes returned
+}
+
+//Skip ahead the indicated number of bytes without outputting any of the data.
+//Returns: number of bytes skipped
+size_t BufferedInput::skip(size_t size)
+{
+	//Read blocks for speed.
+	static const size_t BLOCK_SIZE = 16;
+	char tempBlock[BLOCK_SIZE];
+	size_t i, bytes_read;
+
+	if (this->bFromStdin) {
+		//Skips ahead the requested number of bytes in stdin.
+		size_t advanced = 0;
+
+		const size_t blocks = size/BLOCK_SIZE;
+		for (i = 0; i < blocks; ++i) {
+			bytes_read = fread(tempBlock, 1, BLOCK_SIZE, stdin);
+			advanced += bytes_read;
+			size -= bytes_read;
+		}
+		assert(size < BLOCK_SIZE);
+		advanced += fread(tempBlock, 1, size, stdin);
+		return advanced;
+	}
+
+	//no more data to be read
+	if (eof() || !this->fp) {
+		return 0;
+	}
+
+	const size_t bytesInBuffer = this->length - this->index;
+	if (size <= bytesInBuffer) {
+		//Move ahead by this many bytes within the buffer.
+		this->index += size;
+		return size;
+	}
+
+	//We want to skip more data than what is left in the buffer.
+
+	//1. Advance to the end of the buffer.
+	this->index = this->length;
+	size -= bytesInBuffer;
+	size_t advanced = bytesInBuffer;
+
+	//2. Skip ahead the remaining number of bytes.
+	const size_t blocks = size / BLOCK_SIZE;
+	for (i = 0; i < blocks; ++i) {
+		bytes_read = fread(tempBlock, 1, BLOCK_SIZE, this->fp);
+		advanced += bytes_read;
+		size -= bytes_read;
+	}
+	assert(size < BLOCK_SIZE);
+	advanced += fread(tempBlock, 1, size, this->fp);
+	this->bEOF = feof(this->fp) != 0;
+
+	return advanced;
+}
+
+bool BufferedInput::open()
+{
+	assert(!fp);
+
+	fp = popen(command.c_str(), "r");
+
+	if (fp) {
+		if (!this->buffer) {
+			assert(capacity > 0);
+			this->buffer = new char[capacity];
+		}
+		return true;
+	}
+	return false;
+}
+
+// Obtains a line of data (or as much of a line as can fit) into the supplied buffer.
+//
+// If there isn't enough data in the buffer for the entire line, as much of the line as possible will be stored
+// in the buffer, including a null terminator.
+//
+// The filled buffer will include newline termination, if there is newline termination available (e.g., a
+// line at the end of the file with no terminating newline will result in a buffer without newline termination)
+//
+// Returns a pointer to the filled buffer or nullptr if there is no more data to read into the buffer.
+const char* BufferedInput::getline(char* buf, const size_t size)
+{
+	assert(buf);
+	assert(size);
+
+	if (this->bFromStdin) {
+		return fgets(buf, size, stdin);
+	}
+
+	const size_t size_minus_1 = size - 1;
+	size_t out_pos = 0;
+	while (can_read_more_data()) {
+		while (this->index < this->length) {
+			if (out_pos == size_minus_1) {
+				//Filled output buffer
+				buf[out_pos] = 0;
+				return buf;
+			}
+			const char ch = this->buffer[this->index++];
+			buf[out_pos++] = ch;
+			if (ch == '\n') {
+				buf[out_pos] = 0;
+				return buf;
+			}
+		}
+
+		refill_buffer();
+	}
+
+	return out_pos ? buf : NULL;
+}
+
+} // namespace zdw
+} // namespace adobe
+

--- a/cplusplus/BufferedOutput.cpp
+++ b/cplusplus/BufferedOutput.cpp
@@ -11,10 +11,214 @@
  */
 
 #include "zdw/BufferedOutput.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
 
 
 namespace adobe {
 namespace zdw {
+
+BufferedOrderedOutput::ByteBuffer::ByteBuffer(int unsigned startSize)
+	: pBuffer(new char[startSize])
+	, size(0)
+	, capacity(startSize)
+{ }
+
+BufferedOrderedOutput::ByteBuffer::ByteBuffer(const ByteBuffer& rhs)
+	: pBuffer(new char[rhs.capacity])
+	, size(rhs.size)
+	, capacity(rhs.capacity)
+{
+	memcpy(this->pBuffer, rhs.pBuffer, this->size);
+}
+
+void BufferedOrderedOutput::ByteBuffer::swap(ByteBuffer& rhs)
+{
+	using std::swap;
+	swap(this->pBuffer, rhs.pBuffer);
+	swap(this->size, rhs.size);
+	swap(this->capacity, rhs.capacity);
+}
+
+BufferedOrderedOutput::ByteBuffer& BufferedOrderedOutput::ByteBuffer::operator=(const ByteBuffer& rhs)
+{
+	ByteBuffer(rhs).swap(*this); return *this;
+}
+
+BufferedOrderedOutput::ByteBuffer::~ByteBuffer()
+{
+	delete[] this->pBuffer;
+}
+
+//Write data to the start of the buffer.
+inline void BufferedOrderedOutput::ByteBuffer::write(const void* data, const size_t dataSize)
+{
+	if (this->capacity < dataSize) {
+		//Reserve more memory.
+		const int newSize = dataSize * 2; //exponential growth
+		delete[] this->pBuffer;
+
+		this->capacity = 0;
+		this->pBuffer = NULL; //basic exception safety
+
+		this->pBuffer = new char[newSize];
+		this->capacity = newSize;
+	}
+	memcpy(this->pBuffer, data, dataSize);
+	this->size = dataSize;
+}
+
+
+BufferedOrderedOutput::BufferedOrderedOutput(FILE* fp)
+	: fp(fp)
+	, curColumnIndex(0)
+{ }
+
+BufferedOrderedOutput::~BufferedOrderedOutput()
+{ }
+
+bool BufferedOrderedOutput::write(const void* data, const size_t size)
+{
+	//If we are reordering column outputs, then save the output for when the row is complete.
+	assert(!this->outputIndex.empty());
+	const int unsigned outIndex = this->outputIndex[this->curColumnIndex++];
+
+	//Should not be calling write() for columns that are not written out to any location
+	assert(outIndex < this->outputColumnBuffer.size());
+
+	//Save data for each column in a buffer for special reordering.
+	this->outputColumnBuffer[outIndex].write(data, size);
+	return true; //done for now -- column contents will be written out at the end of the line
+}
+
+//Have an empty string outputted on the current column.
+void BufferedOrderedOutput::writeEmpty()
+{
+	assert(!this->outputIndex.empty());
+	const int unsigned outIndex = this->outputIndex[this->curColumnIndex++];
+
+	//Should not be calling writeEmpty() for columns that are not written out to any location
+	assert(outIndex < this->outputColumnBuffer.size());
+
+	//Save data for each column in a buffer for special reordering.
+	this->outputColumnBuffer[outIndex].reset();
+}
+
+//Completes the current row/line of text.
+bool BufferedOrderedOutput::writeEndline(const void* data, const size_t size)
+{
+	this->curColumnIndex = 0; //ready to receive next line
+
+	if (!this->fp) {
+		return true; //nothing to do
+	}
+
+	//Output column values in specified order.
+	//A single fwrite is noticeably faster than one for each column value.
+	std::string str;
+	str.reserve(this->outputColumnBuffer.size() * 16); //prepare an expected size
+	std::vector<ByteBuffer>::const_iterator colBuf;
+	for (colBuf = this->outputColumnBuffer.begin(); colBuf != this->outputColumnBuffer.end(); ++colBuf) {
+		if (colBuf != this->outputColumnBuffer.begin()) {
+			str.append(1, '\t'); //force column separators to be tabs for now
+		}
+		colBuf->print(str);
+	}
+	str.append(static_cast<const char*>(data), size); //append the endline chars
+	return (fwrite(str.c_str(), str.size(), 1, this->fp) == 1);
+}
+
+bool BufferedOrderedOutput::writeRawLine(const void* data, const size_t size)
+{
+	if (!this->fp) {
+		return true; //nothing to do
+	}
+
+	return fwrite(data, size, 1, this->fp) == 1;
+}
+
+//Call to reorder column outputs in each row/line of text.
+//Input: a vector with an unordered sequence of zero-based indices; values of -1 are ignored
+//
+//Returns: whether the ordering provided was accepted
+bool BufferedOrderedOutput::setOutputColumnOrder(const int* pOutputOrder, const int numColumns)
+{
+	//Start empty.
+	this->outputIndex.clear();
+	this->outputColumnBuffer.clear();
+
+	//Populate column order and buffer to hold each column output.
+	int max_val = -1; //enforce no gaps in the sequence
+	for (int i = 0; i < numColumns; ++i) {
+		const int val = pOutputOrder[i];
+		if (val != -1) { //skip -1 values (use this to indicate a column is being omitted)
+			assert(val >= 0); //negative values are not supported
+			this->outputIndex.push_back(val); //this column should be outputted at this index
+			this->outputColumnBuffer.push_back(ByteBuffer());
+
+			if (val > max_val) {
+				max_val = val;
+			}
+		}
+	}
+
+	//the sequence should have no gaps or repetition in the ordering
+	//i.e. the number of elements added should equal the largest value encountered
+	//     (actually, one greater than the highest zero-based index)
+	//CAVEAT: this doesn't catch pathological cases (e.g. "2, 2, 2" where the size is one greater than the max_val)
+	return (max_val + 1) == int(this->outputIndex.size());
+}
+
+
+BufferedOutput::BufferedOutput(FILE* fp, const size_t capacity)
+	: fp(fp)
+	, capacity(capacity)
+	, buffer(fp ? new char[capacity] : NULL)
+	, index(0)
+{ }
+
+BufferedOutput::~BufferedOutput()
+{
+	flush();
+	delete[] buffer;
+}
+
+//Returns: whether operation succeeded
+bool BufferedOutput::flush()
+{
+	if (!this->index) {
+		return true; //nothing to write
+	}
+
+	assert(this->fp);
+	const size_t out = fwrite(buffer, this->index, 1, this->fp);
+	this->index = 0;
+	return out == 1;
+}
+
+bool BufferedOutput::write(const void* data, const size_t size)
+{
+	if (!this->fp) {
+		return true; //nowhere to write -- nothing to do
+	}
+
+	bool bRet = true;
+	if (this->index + size >= this->capacity) {
+		bRet &= flush();
+	}
+	if (size >= this->capacity) {
+		//Buffer is not large enough to store -- write the data immediately.
+		const size_t out = fwrite(data, size, 1, this->fp);
+		bRet &= (out == 1);
+	} else {
+		//Store for a later write to the file.
+		memcpy(this->buffer + this->index, data, size);
+		this->index += size;
+	}
+	return bRet;
+}
+
 
 int compareByIndex(const void* first, const void* second)
 {
@@ -26,6 +230,159 @@ int compareByOutputIndex(const void* first, const void* second)
 {
 	return (reinterpret_cast<const OutputOrderIndexer *>(first))->outputIndex
 			- (reinterpret_cast<const OutputOrderIndexer *>(second))->outputIndex;
+}
+
+
+BufferedOutputInMem::BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer)
+	: ppBuffer(NULL)
+	, pBuffer(NULL)
+	, pBufferSize(NULL)
+	, index(0), columnNum(0)
+	, pColumns(NULL)
+	, pColumnsBuffer(NULL)
+	, pOutputOrder(NULL)
+	, numColumns(0)
+	, currentRowLength(0)
+	, neededBufferSize(neededBufferSize)
+	, bUseInternalBuffer(bUseInternalBuffer)
+	, bNeedReorder(false)
+{
+	if (bUseInternalBuffer) {
+		this->pBuffer = new char[neededBufferSize];
+	}
+}
+
+BufferedOutputInMem::~BufferedOutputInMem()
+{
+	delete[] this->pOutputOrder;
+	delete[] this->pColumnsBuffer;
+	if (bUseInternalBuffer) {
+		delete [] this->pBuffer;
+	}
+}
+
+// invoke setOutputBuffer before parsing
+void BufferedOutputInMem::setOutputBuffer(char** buffer, size_t *size)
+{
+	assert(buffer);
+	assert(*buffer);
+	assert(size);
+	assert(*size > 0);
+
+	this->ppBuffer = buffer;
+	this->pBuffer = *buffer;
+	this->pBufferSize = size;
+
+	checkBufferSize(neededBufferSize);
+}
+
+//Call whenever output needs to be directed to a new location.
+void BufferedOutputInMem::setOutputColumnPtrs(const char** outColumns)
+{
+	this->pColumns = outColumns;
+	this->pColumns[0] = this->pBuffer; //first column will always be at start of buffer
+}
+
+bool BufferedOutputInMem::setOutputColumnOrder(const int* pOutputOrder, const int numColumns)
+{
+	if (!pOutputOrder || numColumns == 0) {
+		return true;
+	}
+
+	this->pOutputOrder = new int[numColumns];
+	int validNumColumns = 0;
+	for (int i = 0; i < numColumns; i++) {
+		if (pOutputOrder[i] == -1) {
+			continue;
+		}
+		this->pOutputOrder[validNumColumns] = pOutputOrder[i];
+		validNumColumns++;
+	}
+
+	this->numColumns = validNumColumns;
+	this->pColumnsBuffer = new const char*[validNumColumns];
+
+	this->bNeedReorder = true;
+	return true;
+}
+
+bool BufferedOutputInMem::write(const void* data, const size_t size)
+{
+	assert(ppBuffer || bUseInternalBuffer);
+	assert(pBuffer);
+
+	//Add data to current column value.
+	memcpy(this->pBuffer + this->index, data, size);
+	this->index += size;
+	assert(bUseInternalBuffer || this->index < *pBufferSize);
+	return true;
+}
+
+bool BufferedOutputInMem::writeSeparator(const void* /*data*/, const size_t /*size*/)
+{
+	assert(ppBuffer || bUseInternalBuffer);
+	assert(pBuffer);
+
+	//Done with current column.
+	//Terminate it and begin next column.
+	this->pBuffer[this->index++] = 0; //null-delimiter
+	assert(bUseInternalBuffer || this->index < *pBufferSize);
+	this->pColumns[++this->columnNum] = this->pBuffer + this->index;
+	return true;
+}
+
+bool BufferedOutputInMem::writeEndline(const void* /*data*/, const size_t /*size*/)
+{
+	assert(ppBuffer || bUseInternalBuffer);
+	assert(pBuffer);
+
+	//Done with line.  Terminate and reset.
+	this->pBuffer[this->index] = 0; //null-delimiter
+	this->currentRowLength = this->index;
+
+	if (this->bNeedReorder) {
+		reorderOutputColumn();
+	}
+
+	this->index = this->columnNum = 0; //get ready to read next line
+	return true;
+}
+
+bool BufferedOutputInMem::writeRawLine(const void* data, const size_t size)
+{
+	assert(ppBuffer || bUseInternalBuffer);
+	assert(pBuffer);
+
+	memcpy(this->pBuffer, data, size);
+	this->pBuffer[size] = 0;
+	this->currentRowLength = size;
+
+	assert(bUseInternalBuffer || size < *pBufferSize);
+	return true;
+}
+
+void BufferedOutputInMem::reorderOutputColumn()
+{
+	if (!pOutputOrder || numColumns == 0 || !pColumns) {
+		return;
+	}
+
+	for (int i = 0; i < numColumns; i++) {
+		pColumnsBuffer[pOutputOrder[i]] = pColumns[i];
+	}
+	memcpy(pColumns, pColumnsBuffer, sizeof(const char **) * numColumns);
+}
+
+void BufferedOutputInMem::checkBufferSize(const size_t requiredSize)
+{
+	assert(pBufferSize);
+	assert(ppBuffer);
+	if (requiredSize > *pBufferSize) {
+		delete [] pBuffer;
+		pBuffer = new char [requiredSize];
+		*ppBuffer = pBuffer;
+		*pBufferSize = requiredSize;
+	}
 }
 
 } // namespace zdw

--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -4,6 +4,7 @@ project(zdw)
 add_definitions(-D_FILE_OFFSET_BITS=64 -D__STDC_LIMIT_MACROS -Wall -Wold-style-cast)
 
 add_library(zdw
+	BufferedInput.cpp
 	BufferedOutput.cpp
 	ConvertToZDW.cpp
 	ConvertToZDW.h

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -16,12 +16,14 @@
 
 #include "zdw/UnconvertFromZDW.h"
 
-#include <stdint.h>
+#include <algorithm>
 #include <math.h>
 #include <ostream>
-#include <sstream>
-#include <algorithm>
 #include <set>
+#include <sstream>
+#include <stdint.h>
+#include <string.h>
+#include <sys/stat.h>
 #include "zdw_column_type_constants.h"
 
 using namespace adobe::zdw::internal;
@@ -1839,10 +1841,15 @@ void UnconvertFromZDW_Base::EnableVirtualExportRowColumn()
 	indexForVirtualRowColumn = USE_VIRTUAL_COLUMN;
 }
 
+
 //***************************************************************
 //Explicit template class instantiations.
 template class UnconvertFromZDWToFile<BufferedOutput>;
 template class UnconvertFromZDWToFile<BufferedOrderedOutput>;
+
+
+UnconvertFromZDWToMemory::~UnconvertFromZDWToMemory()
+{ }
 
 //***************************************************************
 //

--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -16,9 +16,10 @@
 
 #include "zdw/UnconvertFromZDW.h"
 
+#include <algorithm>
 #include <stdio.h>
 #include <stdlib.h>
-#include <algorithm>
+#include <string.h>
 
 using namespace adobe::zdw;
 using std::string;

--- a/cplusplus/zdw/BufferedInput.h
+++ b/cplusplus/zdw/BufferedInput.h
@@ -13,12 +13,7 @@
 #ifndef BUFFEREDINPUT_H
 #define BUFFEREDINPUT_H
 
-#include <cassert>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string>
-#include <string.h>
-#include <zlib.h>
 
 
 namespace adobe {
@@ -28,58 +23,18 @@ class BufferedInput
 {
 public:
 	// open a pipe via a command and read input from the pipe
-	BufferedInput(const std::string& command, const size_t capacity = 16 * 1024)
-		: command(command)
-		, fp(NULL)
-		, buffer(NULL)
-		, capacity(capacity)
-		, index(0), length(0)
-		, bEOF(false)
-		, bFromStdin(false)
-	{
-		open();
-	}
+	BufferedInput(const std::string& command, const size_t capacity = 16 * 1024);
 
 	// read from standard input
-	BufferedInput()
-		: fp(NULL)
-		, buffer(NULL)
-		, capacity(0)
-		, index(0), length(0)
-		, bEOF(false)
-		, bFromStdin(true)
-	{
-	}
+	BufferedInput();
 
-	~BufferedInput()
-	{
-		close();
-		delete[] buffer;
-	}
+	~BufferedInput();
 
-	void close() {
-		if (fp) {
-			pclose(fp);
-			fp = NULL;
-		}
-	}
-	bool rewind() {
-		bEOF = false;
-		index = length = 0;
-		assert(!command.empty());
-		close();
-		return open();
-	}
+	void close();
+	bool rewind();
 
 	//Returns: whether any more data can be returned
-	bool eof() const
-	{
-		if (this->bFromStdin) {
-			return feof(stdin) != 0;
-		} else {
-			return bEOF && index >= length;
-		}
-	}
+	bool eof() const;
 
 	//Returns: whether file handle appears to be open
 	bool is_open() const { return (this->fp != NULL) || this->bFromStdin; }
@@ -90,158 +45,18 @@ public:
 
 	void reset() { index = length = 0; }
 
-	bool can_read_more_data() const
-	{
-		if (eof())
-			return false;
-		return this->fp != NULL;
-	}
+	bool can_read_more_data() const;
 
-	void refill_buffer()
-	{
-		this->index = this->length = 0;
-		do {
-			//Iterate reads when we don't receive the entire buffer immediately.
-			this->length += fread(this->buffer + this->length,
-				1, this->capacity - this->length, this->fp);
-			this->bEOF = feof(this->fp) != 0;
-		} while (this->length < this->capacity && !this->bEOF);
-	}
+	void refill_buffer();
 
 	//Returns: number of bytes read
-	size_t read(void* data, size_t size)
-	{
-		if (this->bFromStdin) {
-			//Reads requested number of bytes from stdin.
-			return fread(data, 1, size, stdin);
-		}
-
-		if (!can_read_more_data())
-			return 0;
-
-		size_t bytesRead = 0;
-
-		//Asking for more data than is currently in the buffer?
-		size_t bytesInBuffer = this->length - this->index;
-		if (size > bytesInBuffer)
-		{
-			//Flush what is available first.
-			if (bytesInBuffer)
-			{
-				memcpy(data, this->buffer + this->index, bytesInBuffer);
-
-				//If we've hit EOF, then there is no more data to read in.
-				if (this->bEOF)
-					return bytesInBuffer;
-
-				//Prepare to fill the output buffer with more data.
-				size -= bytesInBuffer;
-				data = static_cast<char*>(data) + bytesInBuffer;
-				bytesRead = bytesInBuffer;
-			}
-
-			//Should we read more into the buffer for this call?
-			if (size >= this->capacity)
-			{
-				//Buffer is not large enough to store the rest of the requested data.
-				//Just pass the rest of the data through without buffering.
-				bytesRead += fread(data, 1, size, this->fp);
-				this->bEOF = feof(this->fp) != 0;
-
-				//Buffer is now empty -- refill next call
-				this->index = this->length = 0;
-
-				return bytesRead;
-			}
-
-			refill_buffer();
-			bytesInBuffer = this->length;
-		}
-
-		//Return the amount of data requested.
-		//If there isn't enough data available to fill the request, return what's left
-		if (size > bytesInBuffer)
-			size = bytesInBuffer;
-		memcpy(data, this->buffer + this->index, size);
-		this->index += size;
-
-		return bytesRead + size; //total bytes returned
-	}
+	size_t read(void* data, size_t size);
 
 	//Skip ahead the indicated number of bytes without outputting any of the data.
 	//Returns: number of bytes skipped
-	size_t skip(size_t size)
-	{
-		//Read blocks for speed.
-		static const size_t BLOCK_SIZE = 16;
-		char tempBlock[BLOCK_SIZE];
-		size_t i, bytes_read;
+	size_t skip(size_t size);
 
-		if (this->bFromStdin) {
-			//Skips ahead the requested number of bytes in stdin.
-			size_t advanced = 0;
-
-			const size_t blocks = size/BLOCK_SIZE;
-			for (i = 0; i < blocks; ++i) {
-				bytes_read = fread(tempBlock, 1, BLOCK_SIZE, stdin);
-				advanced += bytes_read;
-				size -= bytes_read;
-			}
-			assert(size < BLOCK_SIZE);
-			advanced += fread(tempBlock, 1, size, stdin);
-			return advanced;
-		}
-
-		//no more data to be read
-		if (eof())
-			return 0;
-		if (!this->fp)
-			return 0;
-
-		const size_t bytesInBuffer = this->length - this->index;
-		if (size <= bytesInBuffer) {
-			//Move ahead by this many bytes within the buffer.
-			this->index += size;
-			return size;
-		}
-
-		//We want to skip more data than what is left in the buffer.
-
-		//1. Advance to the end of the buffer.
-		this->index = this->length;
-		size -= bytesInBuffer;
-		size_t advanced = bytesInBuffer;
-
-		//2. Skip ahead the remaining number of bytes.
-		const size_t blocks = size / BLOCK_SIZE;
-		for (i = 0; i < blocks; ++i) {
-			bytes_read = fread(tempBlock, 1, BLOCK_SIZE, this->fp);
-			advanced += bytes_read;
-			size -= bytes_read;
-		}
-		assert(size < BLOCK_SIZE);
-		advanced += fread(tempBlock, 1, size, this->fp);
-		this->bEOF = feof(this->fp) != 0;
-
-		return advanced;
-	}
-
-	bool open()
-	{
-		assert(!fp);
-
-		fp = popen(command.c_str(), "r");
-
-		if (fp)
-		{
-			if (!this->buffer) {
-				assert(capacity > 0);
-				this->buffer = new char[capacity];
-			}
-			return true;
-		}
-		return false;
-	}
+	bool open();
 
 	// Obtains a line of data (or as much of a line as can fit) into the supplied buffer.
 	//
@@ -252,36 +67,7 @@ public:
 	// line at the end of the file with no terminating newline will result in a buffer without newline termination)
 	//
 	// Returns a pointer to the filled buffer or nullptr if there is no more data to read into the buffer.
-	const char* getline(char* buf, const size_t size)
-	{
-		assert(buf);
-		assert(size);
-
-		if (this->bFromStdin)
-			return fgets(buf, size, stdin);
-
-		const size_t size_minus_1 = size - 1;
-		size_t out_pos = 0;
-		while (can_read_more_data()) {
-			while (this->index < this->length) {
-				if (out_pos == size_minus_1) {
-					//Filled output buffer
-					buf[out_pos] = 0;
-					return buf;
-				}
-				const char ch = this->buffer[this->index++];
-				buf[out_pos++] = ch;
-				if (ch == '\n') {
-					buf[out_pos] = 0;
-					return buf;
-				}
-			}
-
-			refill_buffer();
-		}
-
-		return out_pos ? buf : NULL;
-	}
+	const char* getline(char* buf, const size_t size);
 
 private:
 	std::string command;

--- a/cplusplus/zdw/BufferedOutput.h
+++ b/cplusplus/zdw/BufferedOutput.h
@@ -14,10 +14,6 @@
 #define BUFFEREDOUTPUT_H
 
 #include <vector>
-#include <stdio.h>
-#include <stdlib.h>
-#include <assert.h>
-#include <string.h>
 #include <string>
 
 
@@ -35,46 +31,19 @@ private:
 	class ByteBuffer
 	{
 	public:
-		ByteBuffer(int unsigned startSize = 16)
-		: pBuffer(new char[startSize])
-		, size(0)
-		, capacity(startSize)
-		{ }
-		ByteBuffer(const ByteBuffer& rhs)
-		: pBuffer(new char[rhs.capacity])
-		, size(rhs.size)
-		, capacity(rhs.capacity)
-		{
-			memcpy(this->pBuffer, rhs.pBuffer, this->size);
-		}
-		void swap(ByteBuffer& rhs) {
-			using std::swap;
-			swap(this->pBuffer, rhs.pBuffer);
-			swap(this->size, rhs.size);
-			swap(this->capacity, rhs.capacity);
-		}
-		ByteBuffer& operator=(const ByteBuffer& rhs) { ByteBuffer(rhs).swap(*this); return *this; }
-		~ByteBuffer() { delete[] this->pBuffer; }
+		ByteBuffer(int unsigned startSize = 16);
+		ByteBuffer(const ByteBuffer& rhs);
+
+		void swap(ByteBuffer& rhs);
+
+		ByteBuffer& operator=(const ByteBuffer& rhs);
+		~ByteBuffer();
 
 		//Write data to the start of the buffer.
-		inline void write(const void* data, const size_t dataSize) {
-			if (this->capacity < dataSize) {
-				//Reserve more memory.
-				const int newSize = dataSize * 2; //exponential growth
-				delete[] this->pBuffer;
+		inline void write(const void* data, const size_t dataSize);
 
-				this->capacity = 0;
-				this->pBuffer = NULL; //basic exception safety
+		inline void reset() { this->size = 0; }
 
-				this->pBuffer = new char[newSize];
-				this->capacity = newSize;
-			}
-			memcpy(this->pBuffer, data, dataSize);
-			this->size = dataSize;
-		}
-		inline void reset() {
-			this->size = 0;
-		}
 		inline void print(std::string& str) const { str.append(this->pBuffer, this->size); }
 
 	private:
@@ -84,102 +53,28 @@ private:
 	};
 
 public:
-	BufferedOrderedOutput(FILE* fp)
-		: fp(fp)
-		, curColumnIndex(0)
-	{ }
-	~BufferedOrderedOutput()
-	{ }
+	BufferedOrderedOutput(FILE* fp);
+	~BufferedOrderedOutput();
 
-	bool write(const void* data, const size_t size)
-	{
-		//If we are reordering column outputs, then save the output for when the row is complete.
-		assert(!this->outputIndex.empty());
-		const int unsigned outIndex = this->outputIndex[this->curColumnIndex++];
-
-		//Should not be calling write() for columns that are not written out to any location
-		assert(outIndex < this->outputColumnBuffer.size());
-
-		//Save data for each column in a buffer for special reordering.
-		this->outputColumnBuffer[outIndex].write(data, size);
-		return true; //done for now -- column contents will be written out at the end of the line
-	}
+	bool write(const void* data, const size_t size);
 
 	//Have an empty string outputted on the current column.
-	void writeEmpty()
-	{
-		assert(!this->outputIndex.empty());
-		const int unsigned outIndex = this->outputIndex[this->curColumnIndex++];
-
-		//Should not be calling writeEmpty() for columns that are not written out to any location
-		assert(outIndex < this->outputColumnBuffer.size());
-
-		//Save data for each column in a buffer for special reordering.
-		this->outputColumnBuffer[outIndex].reset();
-	}
+	void writeEmpty();
 
 	//Output a separator between columns.
-	bool writeSeparator(const void*, const size_t) {
-		return true; //we don't need to write any separator now
-	}
+	bool writeSeparator(const void*, const size_t) { return true; } //we don't need to write any separator now
 
 	//Completes the current row/line of text.
-	bool writeEndline(const void* data, const size_t size) {
-		this->curColumnIndex = 0; //ready to receive next line
+	bool writeEndline(const void* data, const size_t size);
 
-		if (!this->fp)
-			return true; //nothing to do
-
-		//Output column values in specified order.
-		//A single fwrite is noticeably faster than one for each column value.
-		std::string str;
-		str.reserve(this->outputColumnBuffer.size() * 16); //prepare an expected size
-		std::vector<ByteBuffer>::const_iterator colBuf;
-		for (colBuf = this->outputColumnBuffer.begin(); colBuf != this->outputColumnBuffer.end(); ++colBuf) {
-			if (colBuf != this->outputColumnBuffer.begin())
-				str.append(1, '\t'); //force column separators to be tabs for now
-			colBuf->print(str);
-		}
-		str.append(static_cast<const char*>(data), size); //append the endline chars
-		return (fwrite(str.c_str(), str.size(), 1, this->fp) == 1);
-	}
-
-	bool writeRawLine(const void* data, const size_t size) {
-		if (!this->fp)
-			return true; //nothing to do
-
-		return fwrite(data, size, 1, this->fp) == 1;
-	}
+	bool writeRawLine(const void* data, const size_t size);
 
 	//Call to reorder column outputs in each row/line of text.
 	//Input: a vector with an unordered sequence of zero-based indices; values of -1 are ignored
 	//
 	//Returns: whether the ordering provided was accepted
-	bool setOutputColumnOrder(const int* pOutputOrder, const int numColumns) {
-		//Start empty.
-		this->outputIndex.clear();
-		this->outputColumnBuffer.clear();
+	bool setOutputColumnOrder(const int* pOutputOrder, const int numColumns);
 
-		//Populate column order and buffer to hold each column output.
-		int max_val = -1; //enforce no gaps in the sequence
-		for (int i = 0; i < numColumns; ++i) {
-			const int val = pOutputOrder[i];
-			if (val != -1) { //skip -1 values (use this to indicate a column is being omitted)
-				assert(val >= 0); //negative values are not supported
-				this->outputIndex.push_back(val); //this column should be outputted at this index
-				this->outputColumnBuffer.push_back(ByteBuffer());
-
-				if (val > max_val)
-					max_val = val;
-			}
-		}
-
-		//the sequence should have no gaps or repetition in the ordering
-		//i.e. the number of elements added should equal the largest value encountered
-		//     (actually, one greater than the highest zero-based index)
-		//CAVEAT: this doesn't catch pathological cases (e.g. "2, 2, 2" where the size is one greater than the max_val)
-		return (max_val + 1) == int(this->outputIndex.size());
-	}
 	void setOutputColumnPtrs(const char**) { } //not needed in this class template version
 
 private:
@@ -191,6 +86,7 @@ private:
 	int curColumnIndex;
 };
 
+
 class BufferedOutput
 {
 private:
@@ -199,50 +95,14 @@ private:
 	BufferedOutput &operator=(BufferedOutput const &);
 
 public:
-	BufferedOutput(FILE* fp, const size_t capacity = 16 * 1024)
-		: fp(fp)
-		, capacity(capacity)
-		, buffer(fp ? new char[capacity] : NULL)
-		, index(0)
-	{
-	}
-	~BufferedOutput()
-	{
-		flush();
-		delete[] buffer;
-	}
+	BufferedOutput(FILE* fp, const size_t capacity = 16 * 1024);
+	~BufferedOutput();
 
 	//Returns: whether operation succeeded
-	bool flush()
-	{
-		if (!this->index)
-			return true; //nothing to write
+	bool flush();
 
-		assert(this->fp);
-		const size_t out = fwrite(buffer, this->index, 1, this->fp);
-		this->index = 0;
-		return out == 1;
-	}
-	bool write(const void* data, const size_t size)
-	{
-		if (!this->fp)
-			return true; //nowhere to write -- nothing to do
+	bool write(const void* data, const size_t size);
 
-		bool bRet = true;
-		if (this->index + size >= this->capacity)
-			bRet &= flush();
-		if (size >= this->capacity)
-		{
-			//Buffer is not large enough to store -- write the data immediately.
-			const size_t out = fwrite(data, size, 1, this->fp);
-			bRet &= (out == 1);
-		} else {
-			//Store for a later write to the file.
-			memcpy(this->buffer + this->index, data, size);
-			this->index += size;
-		}
-		return bRet;
-	}
 	void writeEmpty() { }
 
 	//Output a separator between columns.
@@ -264,186 +124,52 @@ private:
 	size_t index;
 };
 
+
 struct OutputOrderIndexer
 {
 	int index;
 	int outputIndex;
 };
 
+
 extern int compareByIndex(const void* first, const void* second);
 extern int compareByOutputIndex(const void* first, const void* second);
+
 
 //Class to output each row's column values to user-specified char**s.
 class BufferedOutputInMem
 {
 public:
-	BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer = true)
-		: ppBuffer(NULL)
-		, pBuffer(NULL)
-		, pBufferSize(NULL)
-		, index(0), columnNum(0)
-		, pColumns(NULL)
-		, pColumnsBuffer(NULL)
-		, pOutputOrder(NULL)
-		, numColumns(0)
-		, currentRowLength(0)
-		, neededBufferSize(neededBufferSize)
-		, bUseInternalBuffer(bUseInternalBuffer)
-		, bNeedReorder(false)
-	{
-		if (bUseInternalBuffer)
-		{
-			this->pBuffer = new char[neededBufferSize];
-		}
-	}
-
-	~BufferedOutputInMem()
-	{
-		delete[] this->pOutputOrder;
-		delete[] this->pColumnsBuffer;
-		if (bUseInternalBuffer)
-			delete [] this->pBuffer;
-	}
+	BufferedOutputInMem(size_t neededBufferSize, bool bUseInternalBuffer = true);
+	~BufferedOutputInMem();
 
 	// invoke setOutputBuffer before parsing
-	void setOutputBuffer(char** buffer, size_t *size)
-	{
-		assert(buffer);
-		assert(*buffer);
-		assert(size);
-		assert(*size > 0);
-
-		this->ppBuffer = buffer;
-		this->pBuffer = *buffer;
-		this->pBufferSize = size;
-
-		checkBufferSize(neededBufferSize);
-	}
+	void setOutputBuffer(char** buffer, size_t *size);
 
 	//Call whenever output needs to be directed to a new location.
-	void setOutputColumnPtrs(const char** outColumns) {
-		this->pColumns = outColumns;
-		this->pColumns[0] = this->pBuffer; //first column will always be at start of buffer
-	}
+	void setOutputColumnPtrs(const char** outColumns);
 
-	bool setOutputColumnOrder(const int* pOutputOrder, const int numColumns) {
+	bool setOutputColumnOrder(const int* pOutputOrder, const int numColumns);
 
-		if (!pOutputOrder || numColumns == 0)
-		{
-			return true;
-		}
+	bool write(const void* data, const size_t size);
 
-		this->pOutputOrder = new int[numColumns];
-		int validNumColumns = 0;
-		for (int i = 0; i < numColumns; i++)
-		{
-			if (pOutputOrder[i] == -1)
-			{
-				continue;
-			}
-			this->pOutputOrder[validNumColumns] = pOutputOrder[i];
-			validNumColumns++;
-		}
-
-		this->numColumns = validNumColumns;
-		this->pColumnsBuffer = new const char*[validNumColumns];
-
-		this->bNeedReorder = true;
-		return true;
-	}
-
-	bool write(const void* data, const size_t size) {
-		assert(ppBuffer || bUseInternalBuffer);
-		assert(pBuffer);
-
-		//Add data to current column value.
-		memcpy(this->pBuffer + this->index, data, size);
-		this->index += size;
-		assert(bUseInternalBuffer || this->index < *pBufferSize);
-		return true;
-	}
 	void writeEmpty() { }
+	bool writeSeparator(const void* /*data*/, const size_t /*size*/);
+	bool writeEndline(const void* /*data*/, const size_t /*size*/);
+	bool writeRawLine(const void* data, const size_t size);
 
-	bool writeSeparator(const void* /*data*/, const size_t /*size*/) {
-		assert(ppBuffer || bUseInternalBuffer);
-		assert(pBuffer);
+	size_t getNumOutputColumns() { return this->numColumns; }
 
-		//Done with current column.
-		//Terminate it and begin next column.
-		this->pBuffer[this->index++] = 0; //null-delimiter
-		assert(bUseInternalBuffer || this->index < *pBufferSize);
-		this->pColumns[++this->columnNum] = this->pBuffer + this->index;
-		return true;
-	}
-
-	bool writeEndline(const void* /*data*/, const size_t /*size*/) {
-		assert(ppBuffer || bUseInternalBuffer);
-		assert(pBuffer);
-
-		//Done with line.  Terminate and reset.
-		this->pBuffer[this->index] = 0; //null-delimiter
-		this->currentRowLength = this->index;
-
-		if (this->bNeedReorder)
-		{
-			reorderOutputColumn();
-		}
-
-		this->index = this->columnNum = 0; //get ready to read next line
-		return true;
-	}
-
-	bool writeRawLine(const void* data, const size_t size) {
-		assert(ppBuffer || bUseInternalBuffer);
-		assert(pBuffer);
-
-		memcpy(this->pBuffer, data, size);
-		this->pBuffer[size] = 0;
-		this->currentRowLength = size;
-
-		assert(bUseInternalBuffer || size < *pBufferSize);
-		return true;
-	}
-
-	size_t getNumOutputColumns() {
-		return this->numColumns;
-	}
 	//Set by UnconvertFromZDWToMemory to have this class report the number of columns in the ZDW file
 	//Used when the caller does not explicitly request a set of columns
-	void SetNumOutputColumns(size_t num) {
-		this->numColumns = num;
-	}
+	void SetNumOutputColumns(size_t num) { this->numColumns = num; }
 
-	size_t getCurrentRowLength() {
-		return this->currentRowLength;
-	}
+	size_t getCurrentRowLength() { return this->currentRowLength; }
 
 private:
-	void reorderOutputColumn()
-	{
-		if (!pOutputOrder || numColumns == 0 || !pColumns)
-		{
-			return;
-		}
+	void reorderOutputColumn();
 
-		for (int i = 0; i < numColumns; i++)
-		{
-			pColumnsBuffer[pOutputOrder[i]] = pColumns[i];
-		}
-		memcpy(pColumns, pColumnsBuffer, sizeof(const char **) * numColumns);
-	}
-
-	void checkBufferSize(const size_t requiredSize)
-	{
-		assert(pBufferSize);
-		assert(ppBuffer);
-		if (requiredSize > *pBufferSize) {
-			delete [] pBuffer;
-			pBuffer = new char [requiredSize];
-			*ppBuffer = pBuffer;
-			*pBufferSize = requiredSize;
-		}
-	}
+	void checkBufferSize(const size_t requiredSize);
 
 private:
 	char **ppBuffer;

--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -23,7 +23,6 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <sys/stat.h>
 
 #include <boost/scoped_ptr.hpp>
 
@@ -101,10 +100,11 @@ struct MetadataOptions
 	bool bAllowMissingKeys;
 	std::set<std::string> keys;
 
-	MetadataOptions() :
-		bOutputOnlyMetadata(false),
-		bOnlyMetadataKeys(false),
-		bAllowMissingKeys(false) { }
+	MetadataOptions()
+		: bOutputOnlyMetadata(false)
+		, bOnlyMetadataKeys(false)
+		, bAllowMissingKeys(false)
+	{ }
 };
 
 } // namespace internal
@@ -148,10 +148,7 @@ public:
 
 	ERR_CODE GetSchema(std::ostream& stream);
 
-	void setMetadataOptions(const internal::MetadataOptions& options)
-	{
-		this->metadataOptions = options;
-	}
+	void setMetadataOptions(const internal::MetadataOptions& options) { this->metadataOptions = options; }
 
 protected:
 	ERR_CODE outputDescToFile(const std::vector<std::string>& columnNames,
@@ -326,8 +323,7 @@ public:
 	{
 		statusOutput = defaultStatusOutputCallback;
 	}
-	~UnconvertFromZDWToMemory()
-	{ }
+	~UnconvertFromZDWToMemory();
 
 	ERR_CODE getRow(const char** outColumns);
 


### PR DESCRIPTION

## Description

I've moved the bodies of all non-trivial methods from public headers (primarily zdw/BufferedInput.h and zdw/BufferedOutput.h) into cpp files.

## Motivation and Context

As discussed in a slack convo back in October, I was: "bothered by the amount of code in a couple of the header files (primarily zdw/BufferedInput.h), instead of having it in the library."

## How Has This Been Tested?

Ran both the movie-tickets and analytics-hits through the converter/validation/unconverter  

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ X ] Refactoring (shouldn't break anything nor add new functionality)

## Checklist:

- [ X ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ X ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ X ] All new and existing tests passed.
