### PR TITLE
Fix off-by-one bug found (by Caleb) in BufferedOutput::writeEndline()…

### DIFF
--- a/cplusplus/BufferedOutput.cpp
+++ b/cplusplus/BufferedOutput.cpp
@@ -155,6 +155,7 @@ bool BufferedOrderedOutput::writeEndline(const void* data, const size_t size)
 	this->outStr.clear();
 	std::vector<ByteBuffer>::const_iterator colBuf = this->outputColumnBuffer.begin();
 	colBuf->print(this->outStr);
+	++colBuf;
 	for ( ; colBuf != this->outputColumnBuffer.end(); ++colBuf) {
 		this->outStr.append(1, '\t'); //force column separators to be tabs for now
 		colBuf->print(this->outStr);


### PR DESCRIPTION
… which duplicated the first column data

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

