### PR TITLE
Require C++11 Minimum

### DIFF
--- a/cplusplus/CMakeLists.txt
+++ b/cplusplus/CMakeLists.txt
@@ -46,3 +46,6 @@ target_link_libraries(zdw ${ZLIB_LIBRARIES})
 target_link_libraries(unconvertDWfile zdw)
 target_link_libraries(convertDWfile zdw)
 
+set_property(TARGET zdw PROPERTY CXX_STANDARD 11)
+set_property(TARGET unconvertDWfile PROPERTY CXX_STANDARD 11)
+set_property(TARGET convertDWfile PROPERTY CXX_STANDARD 11)

--- a/cplusplus/README.md
+++ b/cplusplus/README.md
@@ -1,0 +1,4 @@
+# ZDW Compression Library
+
+Build Requirements:
+* C++11 compatible compiler.

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -635,9 +635,10 @@ string UnconvertFromZDW_Base::getColumnDesc(const string& name, UCHAR type, size
 		case VIRTUAL_EXPORT_FILE_BASENAME:
 		case VARCHAR:
 		{
-			char temp[32];
+			const size_t TEMP_BUFFER_SIZE=32;
+			char temp[TEMP_BUFFER_SIZE];
 			const int char_size = (this->columnCharSize && this->columnCharSize[index]) ? this->columnCharSize[index] : 255; //before version 7, we don't have a size value
-			sprintf(temp, "varchar(%d)", char_size);
+			snprintf(temp, TEMP_BUFFER_SIZE, "varchar(%d)", char_size);
 			text += temp;
 		}
 		break;
@@ -1269,12 +1270,13 @@ void UnconvertFromZDW<T>::outputDefault(T& buffer, const UCHAR type)
 template <typename T>
 ERR_CODE UnconvertFromZDW<T>::readNextRow(T& buffer)
 {
+	const size_t TEMP_BUFFER_SIZE=64;
 	long u = 0;
 	char *pos;
 	ULONG index;
 	ULONGLONG visid_low = 0;
 	int tempLength;
-	char temp[64];
+	char temp[TEMP_BUFFER_SIZE];
 	bool bColumnWritten = false;
 
 	IncrementCurrentRowNumber();
@@ -1443,7 +1445,7 @@ ERR_CODE UnconvertFromZDW<T>::readNextRow(T& buffer)
 							pos = GetWord(index, row);
 							buffer.write(pos, strlen(pos));
 						} else { //version 1-3
-							tempLength = sprintf(temp, "%0.12lf", (val.n + this->columnBase[c]) / this->decimalFactor);
+							tempLength = snprintf(temp, TEMP_BUFFER_SIZE, "%0.12lf", (val.n + this->columnBase[c]) / this->decimalFactor);
 							buffer.write(temp, tempLength);
 						}
 					} else {

--- a/cplusplus/UnconvertFromZDW.cpp
+++ b/cplusplus/UnconvertFromZDW.cpp
@@ -20,6 +20,7 @@
 #include <math.h>
 #include <ostream>
 #include <set>
+#include <cassert>
 #include <sstream>
 #include <stdint.h>
 #include <string.h>

--- a/cplusplus/unconvertDWfile.cpp
+++ b/cplusplus/unconvertDWfile.cpp
@@ -17,6 +17,7 @@
 #include "zdw/UnconvertFromZDW.h"
 
 #include <algorithm>
+#include <cassert>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/cplusplus/zdw/UnconvertFromZDW.h
+++ b/cplusplus/zdw/UnconvertFromZDW.h
@@ -23,8 +23,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 
 namespace adobe {
@@ -348,7 +347,7 @@ protected:
 	ERR_CODE handleZDWParseBlockHeader();
 
 private:
-	boost::scoped_ptr<BufferedOutputInMem> pBufferedOutput;
+	std::unique_ptr<BufferedOutputInMem> pBufferedOutput;
 	size_t num_output_columns;
 	bool bUseInternalBuffer;
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

* Fixes some warnings around still using `sprintf` a few places.
* Adds optional C++11 support Under `USE_CPP11` CMake Flag, which currently just removes the requirement for boost shared_ptr (which won't work on boost v1.86 or higher under C++0x anyway).
* If not building with C++11, ensures we actually look up the boost include paths (instead of implicitly assuming their location).
* Adds some missing header includes that we're being transitively provided via boost

